### PR TITLE
Create custom kernel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,21 +5,21 @@ orbs:
   github: circleci/github-cli@2
 
 executors:
-  arm64:
+  build:
+    parameters:
+      arch:
+        type: string
+      tag:
+        type: string
+        default: jammy
+      resource_class:
+        type: string
     environment:
-      TARGETARCH: arm64
+      TARGETARCH: << parameters.arch >>
       IN_CONTAINER: "true"
     docker:
-      - image: buildpack-deps:jammy
-    resource_class: petercb/arm64
-  amd64:
-    environment:
-      TARGETARCH: amd64
-      IN_CONTAINER: "true"
-    docker:
-      - image: buildpack-deps:jammy
-    resource_class: petercb/amd64
-
+      - image: buildpack-deps:<< parameters.tag >>
+    resource_class: << parameters.resource_class >>
 
 commands:
   push-artifacts:
@@ -37,10 +37,17 @@ commands:
 jobs:
   build:
     parameters:
+      arch:
+        type: string
       executor:
-        type: executor
-        default: amd64
-    executor: << parameters.executor >>
+        type: string
+        default: build
+      resource_class:
+        type: string
+    executor:
+      name: << parameters.executor >>
+      arch: << parameters.arch >>
+      resource_class: << parameters.resource_class >>
     steps:
       - checkout
       - run:
@@ -71,10 +78,12 @@ workflows:
     jobs:
       - build:
           name: AMD64 RC build
-          executor: amd64
+          arch: amd64
+          resource_class: petercb/amd64
       - build:
           name: ARM64 RC build
-          executor: arm64
+          arch: arm64
+          resource_class: petercb/arm64
 
   tags:
     jobs:
@@ -89,7 +98,8 @@ workflows:
       - build: &tag-build
           name: AMD64 tag release
           context: github
-          executor: amd64
+          arch: amd64
+          resource_class: large
           filters: *filter-tags
           requires:
             - "Create github release"
@@ -98,4 +108,5 @@ workflows:
       - build:
           <<: *tag-build
           name: ARM64 tag release
-          executor: arm64
+          arch: arm64
+          resource_class: arm.large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,24 +67,12 @@ jobs:
 
 
 workflows:
-  feature:
-    jobs:
-      - build:
-          executor: amd64
-          filters:
-            branches:
-              ignore: master
-
   continuous:
     jobs:
-      - build: &rc-build
+      - build:
           name: AMD64 RC build
           executor: amd64
-          filters:
-            branches:
-              only: master
       - build:
-          <<: *rc-build
           name: ARM64 RC build
           executor: arm64
 

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,6 @@ PACKAGE_LIST=(
     "locales"
     "rsync"
     "squashfs-tools"
-    "vim"
     "xz-utils"
     "zstd"
 )
@@ -52,6 +51,10 @@ case "${TARGETARCH=$(uname -m)}" in
         echo "ERROR: Unsupported TARGETARCH '${TARGETARCH}' !!"
         exit 1
 esac
+
+if mountpoint -q "$(pwd)"; then
+    git config --global --add safe.directory "$(pwd)"
+fi
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 DIST_DIR="${PROJECT_ROOT}/dist"

--- a/build.sh
+++ b/build.sh
@@ -16,18 +16,27 @@ fi
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 DIST_DIR="${PROJECT_ROOT}/dist"
 BUILD_ROOT="${PROJECT_ROOT}/build"
+KERNEL_ORIG="${BUILD_ROOT}/kernel-orig"
 KERNEL_WORK="${BUILD_ROOT}/kernel-work"
+DOWNLOAD_DIR="${BUILD_ROOT}/artifacts"
+SOURCE_ROOT="${BUILD_ROOT}/root"
+KERNEL_ROOT="${BUILD_ROOT}/kernel"
+INITRD_ROOT="${BUILD_ROOT}/initrd"
+INITRD_CONFDIR="${BUILD_ROOT}/initrd-conf"
 
 apt-get --assume-yes -qq update
 
-pushd "/tmp"
+rm -rf "${DOWNLOAD_DIR}"
+mkdir -p "${DOWNLOAD_DIR}"
+pushd "${DOWNLOAD_DIR}"
 apt-get --assume-yes -q download linux-firmware linux-source-${KERNEL_VERSION}
 ls -lFa
 VERSION=$(echo linux-source-${KERNEL_VERSION}_*_all.deb | sed -e "s/^linux-source-${KERNEL_VERSION}_//" -e "s/\.[[:digit:]]\+_all\.deb$//")-${KERNEL_FLAVOUR}
 popd
 
-mkdir -p "${BUILD_ROOT}/kernel"
-dpkg-deb -x /tmp/linux-source-${KERNEL_VERSION}_*.deb "${BUILD_ROOT}/kernel"
+rm -rf "${KERNEL_ORIG}"
+mkdir -p "${KERNEL_ORIG}"
+dpkg-deb -x "${DOWNLOAD_DIR}"/linux-source-${KERNEL_VERSION}_*.deb "${KERNEL_ORIG}"
 
 apt-get --assume-yes -qq install --no-install-recommends \
     bc \
@@ -39,6 +48,7 @@ apt-get --assume-yes -qq install --no-install-recommends \
     fakeroot \
     flex \
     gawk  \
+    gcc-aarch64-linux-gnu \
     gnupg2 \
     initramfs-tools \
     kernel-wedge \
@@ -59,13 +69,14 @@ apt-get --assume-yes -qq install --no-install-recommends \
     xz-utils \
     zstd
 
+rm -rf "${KERNEL_WORK}"
 mkdir -p "${KERNEL_WORK}"
-cp -a "${BUILD_ROOT}"/kernel/usr/src/linux-source-*/debian* "${KERNEL_WORK}/"
+cp -a "${KERNEL_ORIG}"/usr/src/linux-source-*/debian* "${KERNEL_WORK}/"
 chmod a+x "${KERNEL_WORK}"/debian*/rules
 chmod a+x "${KERNEL_WORK}"/debian*/scripts/*
 chmod a+x "${KERNEL_WORK}"/debian*/scripts/misc/*
 mkdir -p "${KERNEL_WORK}/debian/stamps"
-tar xf "${BUILD_ROOT}"/kernel/usr/src/linux-source-*/linux-source*.tar.bz2 --strip-components=1 -C "${KERNEL_WORK}"
+tar xf "${KERNEL_ORIG}"/usr/src/linux-source-*/linux-source*.tar.bz2 --strip-components=1 -C "${KERNEL_WORK}"
 rsync -a "${PROJECT_ROOT}/overlay/" "${KERNEL_WORK}"
 cp -a "${KERNEL_WORK}/debian/changelog" "${KERNEL_WORK}/debian.${KERNEL_FLAVOUR}/"
 cp -a "${KERNEL_WORK}/debian.master/control.stub.in" "${KERNEL_WORK}/debian.${KERNEL_FLAVOUR}/"
@@ -76,17 +87,17 @@ cp -a "${KERNEL_WORK}"/debian.master/control.stub.in "${KERNEL_WORK}/debian.${KE
 cp -a "${KERNEL_WORK}"/debian.master/reconstruct "${KERNEL_WORK}/debian.${KERNEL_FLAVOUR}/"
 
 pushd "${KERNEL_WORK}"
-fakeroot debian/rules clean
+debian/rules clean
+debian/rules updateconfigs
 # see https://wiki.ubuntu.com/KernelTeam/KernelMaintenance#Overriding_module_check_failures
-fakeroot debian/rules binary-headers binary-${KERNEL_FLAVOUR} \
+debian/rules binary-headers binary-${KERNEL_FLAVOUR} \
     skipabi=true \
     skipmodule=true \
     skipretpoline=true \
     skipdbg=true
 popd
 
-SOURCE_ROOT=/usr/src/root
-KERNEL_ROOT=/usr/src/kernel
+rm -rf "${SOURCE_ROOT}"
 mkdir -p "${SOURCE_ROOT}"
 
 pushd "${KERNEL_WORK}/.."
@@ -94,56 +105,58 @@ dpkg-deb -x linux-headers-${KERNEL_VERSION}-*-${KERNEL_FLAVOUR}_*_${TARGETARCH}.
 dpkg-deb -x linux-headers-${KERNEL_VERSION}-*_all.deb "${SOURCE_ROOT}"
 dpkg-deb -x linux-image-unsigned-${KERNEL_VERSION}-*_${TARGETARCH}.deb "${SOURCE_ROOT}"
 dpkg-deb -x linux-modules-${KERNEL_VERSION}-*-${KERNEL_FLAVOUR}_*_${TARGETARCH}.deb "${SOURCE_ROOT}"
-dpkg-deb -x /tmp/linux-firmware_*.deb "${SOURCE_ROOT}"
+dpkg-deb -x "${DOWNLOAD_DIR}"/linux-firmware_*.deb "${SOURCE_ROOT}"
 dpkg-deb -x linux-modules-extra-${KERNEL_VERSION}-*-${KERNEL_FLAVOUR}_*_${TARGETARCH}.deb "${SOURCE_ROOT}"
 popd
-{
-    echo 'r8152'
-    echo 'hfs'
-    echo 'hfsplus'
-    echo 'nls_utf8'
-    echo 'nls_iso8859_1'
-} >> /etc/initramfs-tools/modules
-rsync -a ${SOURCE_ROOT}/lib/ /lib/
+
+# Setup initrd
+mkdir -p "${INITRD_CONFDIR}"
+cp /etc/initramfs-tools/initramfs.conf "${INITRD_CONFDIR}/"
+cat <<EOF > "${INITRD_CONFDIR}/modules"
+r8152
+hfs
+hfsplus
+nls_utf8
+nls_iso8859_1
+EOF
+
+rm -rf "/lib/modules/${VERSION}"
+rsync -a "${SOURCE_ROOT}/lib/" /lib/
 
 # Create initrd
-mkdir -p ${KERNEL_ROOT}/lib
-mkdir -p ${KERNEL_ROOT}/headers
-INITRD_ROOT=/usr/src/initrd
-mkdir -p ${INITRD_ROOT}
-pushd ${INITRD_ROOT}
+mkdir -p "${KERNEL_ROOT}/lib"
+mkdir -p "${KERNEL_ROOT}/headers"
+rm -rf "${INITRD_ROOT}"
+mkdir -p "${INITRD_ROOT}"
+pushd "${INITRD_ROOT}"
 echo "Generate initrd"
 depmod "${VERSION}"
-mkinitramfs -c gzip -o ${INITRD_ROOT}.tmp "${VERSION}"
-zcat ${INITRD_ROOT}.tmp | cpio -idm
-rm ${INITRD_ROOT}.tmp
+mkinitramfs -d "${INITRD_CONFDIR}" -c gzip -o "${INITRD_ROOT}.tmp" "${VERSION}"
+zcat "${INITRD_ROOT}.tmp" | cpio -idm
+rm "${INITRD_ROOT}.tmp"
 echo "Generate firmware and module lists"
-find lib/modules -name \*.ko > ${KERNEL_ROOT}/initrd-modules
-echo "lib/modules/${VERSION}/modules.order" >> ${KERNEL_ROOT}/initrd-modules
-echo "lib/modules/${VERSION}/modules.builtin" >> ${KERNEL_ROOT}/initrd-modules
-find lib/firmware -type f > ${KERNEL_ROOT}/initrd-firmware
-find usr/lib/firmware -type f | sed 's!usr/!!' >> ${KERNEL_ROOT}/initrd-firmware
+find lib/modules -name \*.ko > "${KERNEL_ROOT}/initrd-modules"
+echo "lib/modules/${VERSION}/modules.order" >> "${KERNEL_ROOT}/initrd-modules"
+echo "lib/modules/${VERSION}/modules.builtin" >> "${KERNEL_ROOT}/initrd-modules"
+find lib/firmware -type f > "${KERNEL_ROOT}/initrd-firmware"
+find usr/lib/firmware -type f | sed 's!usr/!!' >> "${KERNEL_ROOT}/initrd-firmware"
 popd
-rm -rf ${INITRD_ROOT}
 
 # Copy output assets
-pushd ${SOURCE_ROOT}
-cp -r usr/src/linux-headers* ${KERNEL_ROOT}/headers
-cp -r lib/firmware ${KERNEL_ROOT}/lib/firmware
-cp -r lib/modules ${KERNEL_ROOT}/lib/modules
-cp boot/System.map* ${KERNEL_ROOT}/System.map
-cp boot/config* ${KERNEL_ROOT}/config
-cp boot/vmlinuz-* ${KERNEL_ROOT}/vmlinuz
-echo "${VERSION}" > ${KERNEL_ROOT}/version
+pushd "${SOURCE_ROOT}"
+cp -r usr/src/linux-headers* "${KERNEL_ROOT}/headers"
+cp -r lib/firmware "${KERNEL_ROOT}/lib/firmware"
+cp -r lib/modules "${KERNEL_ROOT}/lib/modules"
+cp boot/System.map* "${KERNEL_ROOT}/System.map"
+cp boot/config* "${KERNEL_ROOT}/config"
+cp boot/vmlinuz-* "${KERNEL_ROOT}/vmlinuz"
+echo "${VERSION}" > "${KERNEL_ROOT}/version"
 popd
 
-mkdir -p ${INITRD_ROOT}/lib
-pushd ${KERNEL_ROOT}
-tar cf - -T initrd-modules -T initrd-firmware | tar xf - -C ${INITRD_ROOT}/
-depmod -b ${INITRD_ROOT} "${VERSION}"
-depmod -b . "${VERSION}"
 mkdir -p "${DIST_DIR}"
-OUTFILE="${DIST_DIR}/kernel-${TARGETARCH}.squashfs"
+pushd "${KERNEL_ROOT}"
+depmod -b . "${VERSION}"
+OUTFILE="${DIST_DIR}/k3os-kernel-${TARGETARCH}.squashfs"
 rm -f "${OUTFILE}"
 mksquashfs . "${OUTFILE}"
 popd

--- a/build.sh
+++ b/build.sh
@@ -47,8 +47,7 @@ apt-get --assume-yes -qq install --no-install-recommends \
     dwarves \
     fakeroot \
     flex \
-    gawk  \
-    gcc-aarch64-linux-gnu \
+    gawk \
     gnupg2 \
     initramfs-tools \
     kernel-wedge \

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,10 @@ cp -a "${KERNEL_WORK}"/debian.master/reconstruct "${KERNEL_WORK}/debian.${KERNEL
 
 pushd "${KERNEL_WORK}"
 debian/rules clean
-debian/rules updateconfigs
+
+if [ "${UPDATECONFIGS:-no}" == "yes" ]; then
+    debian/rules updateconfigs
+fi
 # see https://wiki.ubuntu.com/KernelTeam/KernelMaintenance#Overriding_module_check_failures
 debian/rules binary-headers binary-${KERNEL_FLAVOUR} \
     skipabi=true \

--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,19 @@ apt-get --assume-yes -qq install --no-install-recommends \
     xz-utils \
     zstd
 
+case "${TARGETARCH}" in
+    amd64)
+        apt-get --assume-yes -qq install --no-install-recommends gcc-aarch64-linux-gnu
+        ;;
+    arm64)
+        apt-get --assume-yes -qq install --no-install-recommends gcc-x86-64-linux-gnu
+        ;;
+    *)
+        echo "ERROR: Unsupported TARGETARCH '${TARGETARCH}' !!"
+        exit 1
+esac
+
+
 rm -rf "${KERNEL_WORK}"
 mkdir -p "${KERNEL_WORK}"
 cp -a "${KERNEL_ORIG}"/usr/src/linux-source-*/debian* "${KERNEL_WORK}/"

--- a/build.sh
+++ b/build.sh
@@ -16,12 +16,10 @@ PACKAGE_LIST=(
     "bison"
     "ccache"
     "cpio"
-    "dkms"
     "dwarves"
     "fakeroot"
     "flex"
     "gawk"
-    "gnupg2"
     "initramfs-tools"
     "kernel-wedge"
     "kmod"
@@ -36,8 +34,6 @@ PACKAGE_LIST=(
     "locales"
     "rsync"
     "squashfs-tools"
-    "xz-utils"
-    "zstd"
 )
 
 case "${TARGETARCH=$(uname -m)}" in
@@ -127,7 +123,7 @@ dpkg-deb -x linux-modules-extra-${KERNEL_VERSION}-*-${KERNEL_FLAVOUR}_*_${TARGET
 popd
 
 # Setup initrd
-mkdir -p "${INITRD_CONFDIR}"
+mkdir -p "${INITRD_CONFDIR}/scripts"
 cp /etc/initramfs-tools/initramfs.conf "${INITRD_CONFDIR}/"
 cat <<EOF > "${INITRD_CONFDIR}/modules"
 r8152
@@ -140,7 +136,7 @@ EOF
 rm -rf "/lib/modules/${VERSION}"
 rsync -a "${SOURCE_ROOT}/lib/" /lib/
 
-# Create initrd
+# Create initrd packing lists
 mkdir -p "${KERNEL_ROOT}/lib"
 mkdir -p "${KERNEL_ROOT}/headers"
 rm -rf "${INITRD_ROOT}"

--- a/overlay/debian.k3os/config/annotations
+++ b/overlay/debian.k3os/config/annotations
@@ -1300,8 +1300,6 @@ CONFIG_CB710_DEBUG                              policy<{'amd64': '-', 'arm64': '
 CONFIG_CB710_DEBUG_ASSUMPTIONS                  policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC10001_ADC                              policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CCS811                                   policy<{'amd64': '-', 'arm64': '-'}>
-CONFIG_CC_CAN_LINK                              policy<{'amd64': 'y', 'arm64': '-'}>
-CONFIG_CC_CAN_LINK_STATIC                       policy<{'amd64': 'y', 'arm64': '-'}>
 CONFIG_CC_HAS_UBSAN_BOUNDS                      policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CDNS_I3C_MASTER                          policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CDROM_PKTCDVD                            policy<{'amd64': 'n', 'arm64': 'n'}>

--- a/overlay/debian.k3os/config/annotations
+++ b/overlay/debian.k3os/config/annotations
@@ -1300,8 +1300,6 @@ CONFIG_CB710_DEBUG                              policy<{'amd64': '-', 'arm64': '
 CONFIG_CB710_DEBUG_ASSUMPTIONS                  policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC10001_ADC                              policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CCS811                                   policy<{'amd64': '-', 'arm64': '-'}>
-CONFIG_CC_CAN_LINK                              policy<{'amd64': 'y', 'arm64': '-'}>
-CONFIG_CC_CAN_LINK_STATIC                       policy<{'amd64': 'y', 'arm64': '-'}>
 CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN             policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO                policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_BARE           policy<{'amd64': '-', 'arm64': '-'}>

--- a/overlay/debian.k3os/config/annotations
+++ b/overlay/debian.k3os/config/annotations
@@ -1300,13 +1300,6 @@ CONFIG_CB710_DEBUG                              policy<{'amd64': '-', 'arm64': '
 CONFIG_CB710_DEBUG_ASSUMPTIONS                  policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC10001_ADC                              policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CCS811                                   policy<{'amd64': '-', 'arm64': '-'}>
-CONFIG_CC_CAN_LINK                              policy<{'amd64': 'y', 'arm64': '-'}>
-CONFIG_CC_CAN_LINK_STATIC                       policy<{'amd64': 'y', 'arm64': '-'}>
-CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN             policy<{'amd64': '-', 'arm64': '-'}>
-CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO                policy<{'amd64': '-', 'arm64': '-'}>
-CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_BARE           policy<{'amd64': '-', 'arm64': '-'}>
-CONFIG_CC_HAS_UBSAN_BOUNDS                      policy<{'amd64': '-', 'arm64': '-'}>
-CONFIG_CC_HAVE_SHADOW_CALL_STACK                policy<{'arm64': '-'}>
 CONFIG_CDNS_I3C_MASTER                          policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CDROM_PKTCDVD                            policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_CDROM_PKTCDVD_BUFFERS                    policy<{'amd64': '-', 'arm64': '-'}>

--- a/overlay/debian.k3os/config/annotations
+++ b/overlay/debian.k3os/config/annotations
@@ -1300,6 +1300,8 @@ CONFIG_CB710_DEBUG                              policy<{'amd64': '-', 'arm64': '
 CONFIG_CB710_DEBUG_ASSUMPTIONS                  policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC10001_ADC                              policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CCS811                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CC_CAN_LINK                              policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_CC_CAN_LINK_STATIC                       policy<{'amd64': 'y', 'arm64': '-'}>
 CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN             policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO                policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_BARE           policy<{'amd64': '-', 'arm64': '-'}>

--- a/overlay/debian.k3os/config/annotations
+++ b/overlay/debian.k3os/config/annotations
@@ -1300,6 +1300,9 @@ CONFIG_CB710_DEBUG                              policy<{'amd64': '-', 'arm64': '
 CONFIG_CB710_DEBUG_ASSUMPTIONS                  policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CC10001_ADC                              policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CCS811                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CC_CAN_LINK                              policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_CC_CAN_LINK_STATIC                       policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_CC_HAS_UBSAN_BOUNDS                      policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CDNS_I3C_MASTER                          policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_CDROM_PKTCDVD                            policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_CDROM_PKTCDVD_BUFFERS                    policy<{'amd64': '-', 'arm64': '-'}>

--- a/overlay/debian.k3os/config/annotations
+++ b/overlay/debian.k3os/config/annotations
@@ -6,11 +6,9570 @@
 
 include "../../debian.master/config/annotations"
 
+CONFIG_ACCESSIBILITY                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACCESSIBILITY                            note<'TODO: update note'>
+
+CONFIG_ACPI_CUSTOM_DSDT_FILE                    policy<{'amd64': '-'}>
+CONFIG_ACPI_CUSTOM_DSDT_FILE                    note<'TODO: update note'>
+
+CONFIG_AGP                                      policy<{'amd64': 'n'}>
+CONFIG_AGP                                      note<'TODO: update note'>
+
+CONFIG_ARMV8_DEPRECATED                         policy<{'arm64': 'n'}>
+CONFIG_ARMV8_DEPRECATED                         note<'TODO: update note'>
+
+CONFIG_ARM_SMMU_DISABLE_BYPASS_BY_DEFAULT       policy<{'arm64': 'y'}>
+CONFIG_ARM_SMMU_DISABLE_BYPASS_BY_DEFAULT       note<'TODO: update note'>
+
+CONFIG_CMA                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CMA                                      note<'TODO: update note'>
+
+CONFIG_CMA_SIZE_MBYTES                          policy<{'arm64': '-'}>
+CONFIG_CMA_SIZE_MBYTES                          note<'TODO: update note'>
+
+CONFIG_CP15_BARRIER_EMULATION                   policy<{'arm64': '-'}>
+CONFIG_CP15_BARRIER_EMULATION                   note<'TODO: update note'>
+
+CONFIG_CRASH_DUMP                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRASH_DUMP                               note<'TODO: update note'>
+
+CONFIG_DEFAULT_MMAP_MIN_ADDR                    policy<{'amd64': '4096', 'arm64': '4096'}>
+CONFIG_DEFAULT_MMAP_MIN_ADDR                    note<'TODO: update note'>
+
+CONFIG_DMA_CMA                                  policy<{'arm64': '-'}>
+CONFIG_DMA_CMA                                  note<'TODO: update note'>
+
+CONFIG_DM_VERITY_VERIFY_ROOTHASH_SIG_SECONDARY_KEYRING policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DM_VERITY_VERIFY_ROOTHASH_SIG_SECONDARY_KEYRING note<'TODO: update note'>
+
+CONFIG_DRM_AMDGPU_CIK                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_AMDGPU_CIK                           note<'TODO: update note'>
+
+CONFIG_DRM_HISI_HIBMC                           policy<{'arm64': '-'}>
+CONFIG_DRM_HISI_HIBMC                           note<'TODO: update note'>
+
+CONFIG_DRM_LEGACY                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_LEGACY                               note<'TODO: update note'>
+
+CONFIG_DRM_MGAG200                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_MGAG200                              note<'TODO: update note'>
+
+CONFIG_DRM_VBOXVIDEO                            policy<{'amd64': '-'}>
+CONFIG_DRM_VBOXVIDEO                            note<'TODO: update note'>
+
+CONFIG_DVB_DUMMY_FE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DUMMY_FE                             note<'TODO: update note'>
+
+CONFIG_ECRYPT_FS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ECRYPT_FS                                note<'TODO: update note'>
+
+CONFIG_EVM                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EVM                                      note<'TODO: update note'>
+
+CONFIG_EVM_ATTR_FSUUID                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EVM_ATTR_FSUUID                          note<'TODO: update note'>
+
+CONFIG_EVM_LOAD_X509                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EVM_LOAD_X509                            note<'TODO: update note'>
+
+CONFIG_FUSE_FS                                  policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_FUSE_FS                                  note<'TODO: update note'>
+
+CONFIG_FW_LOADER_COMPRESS_ZSTD                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FW_LOADER_COMPRESS_ZSTD                  note<'TODO: update note'>
+
+CONFIG_FW_LOADER_USER_HELPER_FALLBACK           policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_FW_LOADER_USER_HELPER_FALLBACK           note<'TODO: update note'>
+
+CONFIG_GPIO_TWL4030                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_TWL4030                             note<'TODO: update note'>
+
+CONFIG_HIBERNATION                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HIBERNATION                              note<'TODO: update note'>
+
+CONFIG_HOTPLUG_PCI_SHPC                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HOTPLUG_PCI_SHPC                         note<'TODO: update note'>
+
+CONFIG_I2C_CHARDEV                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_CHARDEV                              note<'TODO: update note'>
+
+CONFIG_IIO_SIMPLE_DUMMY_BUFFER                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_SIMPLE_DUMMY_BUFFER                  note<'TODO: update note'>
+
+CONFIG_IIO_SIMPLE_DUMMY_EVENTS                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_SIMPLE_DUMMY_EVENTS                  note<'TODO: update note'>
+
+CONFIG_IMA_ARCH_POLICY                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IMA_ARCH_POLICY                          note<'TODO: update note'>
+
+CONFIG_IMA_KEXEC                                policy<{'arm64': '-'}>
+CONFIG_IMA_KEXEC                                note<'TODO: update note'>
+
+CONFIG_IMA_KEYRINGS_PERMIT_SIGNED_BY_BUILTIN_OR_SECONDARY policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IMA_KEYRINGS_PERMIT_SIGNED_BY_BUILTIN_OR_SECONDARY note<'TODO: update note'>
+
+CONFIG_INPUT_UINPUT                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_UINPUT                             note<'TODO: update note'>
+
+CONFIG_INTEGRITY_PLATFORM_KEYRING               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEGRITY_PLATFORM_KEYRING               note<'TODO: update note'>
+
+CONFIG_IPDDP                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPDDP                                    note<'TODO: update note'>
+
+CONFIG_IPMMU_VMSA                               policy<{'arm64': '-'}>
+CONFIG_IPMMU_VMSA                               note<'TODO: update note'>
+
+CONFIG_KEXEC_BZIMAGE_VERIFY_SIG                 policy<{'amd64': '-'}>
+CONFIG_KEXEC_BZIMAGE_VERIFY_SIG                 note<'TODO: update note'>
+
+CONFIG_KFENCE_STATIC_KEYS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KFENCE_STATIC_KEYS                       note<'TODO: update note'>
+
+CONFIG_KGDB_SERIAL_CONSOLE                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KGDB_SERIAL_CONSOLE                      note<'TODO: update note'>
+
+CONFIG_MEMORY_HOTPLUG_DEFAULT_ONLINE            policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MEMORY_HOTPLUG_DEFAULT_ONLINE            note<'TODO: update note'>
+
+CONFIG_MFD_SM501                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_SM501                                note<'TODO: update note'>
+
+CONFIG_MFD_TPS65217                             policy<{'arm64': 'n'}>
+CONFIG_MFD_TPS65217                             note<'TODO: update note'>
+
+CONFIG_MMC_BLOCK                                policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_MMC_BLOCK                                note<'TODO: update note'>
+
+CONFIG_MODVERSIONS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MODVERSIONS                              note<'TODO: update note'>
+
+CONFIG_MTD_BLOCK                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_BLOCK                                note<'TODO: update note'>
+
+CONFIG_MTD_NAND_DISKONCHIP_BBTWRITE             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_DISKONCHIP_BBTWRITE             note<'TODO: update note'>
+
+CONFIG_MTD_ONENAND_VERIFY_WRITE                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_ONENAND_VERIFY_WRITE                 note<'TODO: update note'>
+
+CONFIG_MTD_RAW_NAND                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_RAW_NAND                             note<'TODO: update note'>
+
+CONFIG_NOP_USB_XCEIV                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NOP_USB_XCEIV                            note<'TODO: update note'>
+
+CONFIG_NOUVEAU_LEGACY_CTX_SUPPORT               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NOUVEAU_LEGACY_CTX_SUPPORT               note<'TODO: update note'>
+
+CONFIG_NR_CPUS                                  policy<{'amd64': '256', 'arm64': '256'}>
+CONFIG_NR_CPUS                                  note<'TODO: update note'>
+
+CONFIG_NUMA_EMU                                 policy<{'amd64': 'n'}>
+CONFIG_NUMA_EMU                                 note<'TODO: update note'>
+
+CONFIG_N_GSM                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_N_GSM                                    note<'TODO: update note'>
+
+CONFIG_OSNOISE_TRACER                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_OSNOISE_TRACER                           note<'TODO: update note'>
+
+CONFIG_PAGE_POISONING                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PAGE_POISONING                           note<'TODO: update note'>
+
+CONFIG_PANIC_ON_OOPS                            policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_PANIC_ON_OOPS                            note<'TODO: update note'>
+
+CONFIG_PATA_HPT3X3_DMA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PATA_HPT3X3_DMA                          note<'TODO: update note'>
+
+CONFIG_PCIE_EDR                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCIE_EDR                                 note<'TODO: update note'>
+
+CONFIG_PINCTRL_CHERRYVIEW                       policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_CHERRYVIEW                       note<'TODO: update note'>
+
+CONFIG_REGULATOR_FIXED_VOLTAGE                  policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_REGULATOR_FIXED_VOLTAGE                  note<'TODO: update note'>
+
+CONFIG_REGULATOR_TPS65217                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_TPS65217                       note<'TODO: update note'>
+
+CONFIG_REGULATOR_TWL4030                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_TWL4030                        note<'TODO: update note'>
+
+CONFIG_RTC_DRV_TWL4030                          policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_TWL4030                          note<'TODO: update note'>
+
+CONFIG_SAMPLE_TRACE_PRINTK                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_TRACE_PRINTK                      note<'TODO: update note'>
+
+CONFIG_SCSI_IPR_DUMP                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_IPR_DUMP                            note<'TODO: update note'>
+
+CONFIG_SCSI_IPR_TRACE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_IPR_TRACE                           note<'TODO: update note'>
+
+CONFIG_SECURITY_SAFESETID                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SECURITY_SAFESETID                       note<'TODO: update note'>
+
+CONFIG_SERIAL_MULTI_INSTANTIATE                 policy<{'amd64': '-'}>
+CONFIG_SERIAL_MULTI_INSTANTIATE                 note<'TODO: update note'>
+
+CONFIG_SERIAL_SH_SCI                            policy<{'arm64': '-'}>
+CONFIG_SERIAL_SH_SCI                            note<'TODO: update note'>
+
+CONFIG_SERIAL_SH_SCI_CONSOLE                    policy<{'arm64': '-'}>
+CONFIG_SERIAL_SH_SCI_CONSOLE                    note<'TODO: update note'>
+
+CONFIG_SERIAL_SH_SCI_EARLYCON                   policy<{'arm64': '-'}>
+CONFIG_SERIAL_SH_SCI_EARLYCON                   note<'TODO: update note'>
+
+CONFIG_SETEND_EMULATION                         policy<{'arm64': '-'}>
+CONFIG_SETEND_EMULATION                         note<'TODO: update note'>
+
+CONFIG_SMC                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMC                                      note<'TODO: update note'>
+
+CONFIG_SMC_DIAG                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMC_DIAG                                 note<'TODO: update note'>
+
+CONFIG_SND                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND                                      note<'TODO: update note'>
+
+CONFIG_SND_HDA_POWER_SAVE_DEFAULT               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_POWER_SAVE_DEFAULT               note<'TODO: update note'>
+
+CONFIG_SND_HDA_RECONFIG                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_RECONFIG                         note<'TODO: update note'>
+
+CONFIG_SND_HDA_SCODEC_CS35L41                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_SCODEC_CS35L41                   note<'TODO: update note'>
+
+CONFIG_SND_HDA_SCODEC_CS35L41_I2C               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_SCODEC_CS35L41_I2C               note<'TODO: update note'>
+
+CONFIG_SND_HDA_SCODEC_CS35L41_SPI               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_SCODEC_CS35L41_SPI               note<'TODO: update note'>
+
+CONFIG_SND_PCM_OSS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PCM_OSS                              note<'TODO: update note'>
+
+CONFIG_SND_SOC                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC                                  note<'TODO: update note'>
+
+CONFIG_SND_SOC_AMD_ACP6x                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_AMD_ACP6x                        note<'TODO: update note'>
+
+CONFIG_SND_SOC_AMD_RENOIR                       policy<{'amd64': '-'}>
+CONFIG_SND_SOC_AMD_RENOIR                       note<'TODO: update note'>
+
+CONFIG_SND_SOC_AMD_RENOIR_MACH                  policy<{'amd64': '-'}>
+CONFIG_SND_SOC_AMD_RENOIR_MACH                  note<'TODO: update note'>
+
+CONFIG_SND_SOC_AMD_YC_MACH                      policy<{'amd64': '-'}>
+CONFIG_SND_SOC_AMD_YC_MACH                      note<'TODO: update note'>
+
+CONFIG_SND_SOC_CS35L41                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L41                          note<'TODO: update note'>
+
+CONFIG_SND_SOC_CS35L41_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L41_I2C                      note<'TODO: update note'>
+
+CONFIG_SND_SOC_CS35L41_LIB                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L41_LIB                      note<'TODO: update note'>
+
+CONFIG_SND_SOC_CS35L41_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L41_SPI                      note<'TODO: update note'>
+
+CONFIG_SND_SOC_INTEL_CFL                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CFL                        note<'TODO: update note'>
+
+CONFIG_SND_SOC_INTEL_CML_H                      policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CML_H                      note<'TODO: update note'>
+
+CONFIG_SND_SOC_INTEL_CML_LP                     policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CML_LP                     note<'TODO: update note'>
+
+CONFIG_SND_SOC_INTEL_CNL                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CNL                        note<'TODO: update note'>
+
+CONFIG_SND_SOC_INTEL_SKYLAKE                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKYLAKE                    note<'TODO: update note'>
+
+CONFIG_SND_SOC_INTEL_SKYLAKE_HDAUDIO_CODEC      policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKYLAKE_HDAUDIO_CODEC      note<'TODO: update note'>
+
+CONFIG_SND_SOC_INTEL_SOUNDWIRE_SOF_MACH         policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SOUNDWIRE_SOF_MACH         note<'TODO: update note'>
+
+CONFIG_SND_SOC_INTEL_USER_FRIENDLY_LONG_NAMES   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_USER_FRIENDLY_LONG_NAMES   note<'TODO: update note'>
+
+CONFIG_SND_SOC_SOF_HDA_AUDIO_CODEC              policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_HDA_AUDIO_CODEC              note<'TODO: update note'>
+
+CONFIG_SND_SOC_SOF_HDA_LINK                     policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_HDA_LINK                     note<'TODO: update note'>
+
+CONFIG_SOUND                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SOUND                                    note<'TODO: update note'>
+
+CONFIG_SOUNDWIRE                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SOUNDWIRE                                note<'TODO: update note'>
+
+CONFIG_SOUND_OSS_CORE_PRECLAIM                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SOUND_OSS_CORE_PRECLAIM                  note<'TODO: update note'>
+
+CONFIG_SPEAKUP                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP                                  note<'TODO: update note'>
+
+CONFIG_SPI_INTEL_SPI_PCI                        policy<{'amd64': '-'}>
+CONFIG_SPI_INTEL_SPI_PCI                        note<'TODO: update note'>
+
+CONFIG_SPI_INTEL_SPI_PLATFORM                   policy<{'amd64': '-'}>
+CONFIG_SPI_INTEL_SPI_PLATFORM                   note<'TODO: update note'>
+
+CONFIG_SWP_EMULATION                            policy<{'arm64': '-'}>
+CONFIG_SWP_EMULATION                            note<'TODO: update note'>
+
+CONFIG_TEST_BLACKHOLE_DEV                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TEST_BLACKHOLE_DEV                       note<'TODO: update note'>
+
+CONFIG_TIMERLAT_TRACER                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TIMERLAT_TRACER                          note<'TODO: update note'>
+
+CONFIG_TOUCHSCREEN_ELAN                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ELAN                         note<'TODO: update note'>
+
+CONFIG_UBSAN                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UBSAN                                    note<'TODO: update note'>
+
+CONFIG_UNWINDER_FRAME_POINTER                   policy<{'amd64': 'n'}>
+CONFIG_UNWINDER_FRAME_POINTER                   note<'TODO: update note'>
+
+CONFIG_USB_EHCI_HCD                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_EHCI_HCD                             note<'TODO: update note'>
+
+CONFIG_USB_EHCI_HCD_PLATFORM                    policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_EHCI_HCD_PLATFORM                    note<'TODO: update note'>
+
+CONFIG_USB_HCD_BCMA                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_HCD_BCMA                             note<'TODO: update note'>
+
+CONFIG_USB_HCD_SSB                              policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_USB_HCD_SSB                              note<'TODO: update note'>
+
+CONFIG_USB_M66592                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_M66592                               note<'TODO: update note'>
+
+CONFIG_USB_MUSB_HDRC                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_MUSB_HDRC                            note<'TODO: update note'>
+
+CONFIG_USB_OHCI_HCD                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_OHCI_HCD                             note<'TODO: update note'>
+
+CONFIG_USB_SERIAL_DEBUG                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_DEBUG                         note<'TODO: update note'>
+
+CONFIG_USB_UHCI_HCD                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_UHCI_HCD                             note<'TODO: update note'>
+
+CONFIG_USB_XHCI_DBGCAP                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_XHCI_DBGCAP                          note<'TODO: update note'>
+
+CONFIG_USB_XHCI_HCD                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_XHCI_HCD                             note<'TODO: update note'>
+
+CONFIG_VIDEO_VIMC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VIMC                               note<'TODO: update note'>
+
+CONFIG_VMWARE_VMCI                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VMWARE_VMCI                              note<'TODO: update note'>
+
+CONFIG_VMWARE_VMCI_VSOCKETS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VMWARE_VMCI_VSOCKETS                     note<'TODO: update note'>
+
+CONFIG_WWAN                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WWAN                                     note<'TODO: update note'>
+
+CONFIG_X86_POWERNOW_K8                          policy<{'amd64': 'n'}>
+CONFIG_X86_POWERNOW_K8                          note<'TODO: update note'>
+
+CONFIG_X86_SPEEDSTEP_CENTRINO                   policy<{'amd64': 'n'}>
+CONFIG_X86_SPEEDSTEP_CENTRINO                   note<'TODO: update note'>
+
+CONFIG_X86_UV                                   policy<{'amd64': '-'}>
+CONFIG_X86_UV                                   note<'TODO: update note'>
+
+
+# ---- Annotations without notes ----
+
+CONFIG_104_QUAD_8                               policy<{'amd64': '-'}>
+CONFIG_60XX_WDT                                 policy<{'amd64': 'n'}>
+CONFIG_6LOWPAN                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_6LOWPAN_DEBUGFS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_GHC_EXT_HDR_DEST                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_GHC_EXT_HDR_FRAG                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_GHC_EXT_HDR_HOP                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_GHC_EXT_HDR_ROUTE                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_GHC_ICMPV6                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_GHC_UDP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_NHC                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_NHC_DEST                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_NHC_FRAGMENT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_NHC_HOP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_NHC_IPV6                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_NHC_MOBILITY                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_NHC_ROUTING                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6LOWPAN_NHC_UDP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_6PACK                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_842_COMPRESS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_842_DECOMPRESS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_88EU_AP_MODE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_A11Y_BRAILLE_CONSOLE                     policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_AAEON_IWMI_WDT                           policy<{'amd64': '-'}>
+CONFIG_ABP060MG                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AC97_BUS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ACERHDF                                  policy<{'amd64': 'n'}>
+CONFIG_ACER_WIRELESS                            policy<{'amd64': 'n'}>
+CONFIG_ACER_WMI                                 policy<{'amd64': '-'}>
+CONFIG_ACPI_AC                                  policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_ACPI_ADXL                                policy<{'amd64': '-'}>
+CONFIG_ACPI_ALS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ACPI_APEI                                policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_ACPI_APEI_EINJ                           policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_ACPI_APEI_ERST_DEBUG                     policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_ACPI_APEI_GHES                           policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_ACPI_APEI_MEMORY_FAILURE                 policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_ACPI_APEI_PCIEAER                        policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_ACPI_APEI_SEA                            policy<{'arm64': '-'}>
+CONFIG_ACPI_BGRT                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACPI_CMPC                                policy<{'amd64': 'n'}>
+CONFIG_ACPI_CONFIGFS                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACPI_CPPC_CPUFREQ                        policy<{'arm64': 'n'}>
+CONFIG_ACPI_CPPC_CPUFREQ_FIE                    policy<{'arm64': '-'}>
+CONFIG_ACPI_CPPC_LIB                            policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_ACPI_DEBUG                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACPI_DEBUGGER                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACPI_DEBUGGER_USER                       policy<{'amd64': '-'}>
+CONFIG_ACPI_DOCK                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACPI_DPTF                                policy<{'amd64': 'n'}>
+CONFIG_ACPI_EC_DEBUGFS                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACPI_EXTLOG                              policy<{'amd64': 'n'}>
+CONFIG_ACPI_FAN                                 policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_ACPI_FPDT                                policy<{'amd64': 'n'}>
+CONFIG_ACPI_HED                                 policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_ACPI_HMAT                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACPI_HOTPLUG_MEMORY                      policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_ACPI_I2C_OPREGION                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ACPI_IPMI                                policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_ACPI_MDIO                                policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_ACPI_NFIT                                policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_ACPI_PCI_SLOT                            policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_ACPI_PLATFORM_PROFILE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ACPI_PROCESSOR_AGGREGATOR                policy<{'amd64': 'y'}>
+CONFIG_ACPI_SBS                                 policy<{'amd64': 'n'}>
+CONFIG_ACPI_TAD                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ACPI_TINY_POWER_BUTTON                   policy<{'amd64': '-'}>
+CONFIG_ACPI_TOSHIBA                             policy<{'amd64': '-'}>
+CONFIG_ACPI_VIDEO                               policy<{'amd64': '-'}>
+CONFIG_ACPI_VIOT                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ACPI_WATCHDOG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ACPI_WMI                                 policy<{'amd64': 'n'}>
+CONFIG_ACQUIRE_WDT                              policy<{'amd64': 'n'}>
+CONFIG_ACRN_GUEST                               policy<{'amd64': 'n'}>
+CONFIG_ACRN_HSM                                 policy<{'amd64': '-'}>
+CONFIG_AD2S1200                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD2S1210                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD2S90                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5064                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5110                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD525X_DPOT                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AD525X_DPOT_I2C                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD525X_DPOT_SPI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5272                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5360                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5380                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5421                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5446                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5449                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5504                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5592R                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5592R_BASE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5593R                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5624R_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5686                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5686_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5696_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5755                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5758                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5761                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5764                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5766                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5770R                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5791                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD5933                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7091R5                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7124                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7150                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7192                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7266                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7280                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7291                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7292                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7298                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7303                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7476                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7606                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7606_IFACE_PARALLEL                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7606_IFACE_SPI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7746                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7766                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7768_1                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7780                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7791                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7793                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7816                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7887                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7923                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD7949                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD799X                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD8366                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD8801                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD9467                                   policy<{'arm64': '-'}>
+CONFIG_AD9523                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD9832                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD9834                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADAPTEC_STARFIRE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADE7854                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADE7854_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADE7854_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADF4350                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADF4371                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADFS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ADFS_FS_RW                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIN_PHY                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ADIS16080                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16130                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16136                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16201                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16203                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16209                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16240                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16260                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16400                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16460                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16475                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADIS16480                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADI_AXI_ADC                              policy<{'arm64': '-'}>
+CONFIG_ADJD_S311                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADM8211                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADT7316                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADT7316_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADT7316_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADUX1020                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADVANTECH_WDT                            policy<{'amd64': 'n'}>
+CONFIG_ADV_SWBUTTON                             policy<{'amd64': 'n'}>
+CONFIG_ADXL372                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADXL372_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADXL372_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADXRS290                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ADXRS450                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AD_SIGMA_DELTA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AFE4403                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AFE4404                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AFFS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AFS_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AFS_DEBUG_CURSOR                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AFS_FSCACHE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AF_KCM                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AF_RXRPC                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AF_RXRPC_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AF_RXRPC_INJECT_LOSS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AF_RXRPC_IPV6                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AGP_AMD64                                policy<{'amd64': '-'}>
+CONFIG_AGP_INTEL                                policy<{'amd64': '-'}>
+CONFIG_AGP_SIS                                  policy<{'amd64': '-'}>
+CONFIG_AGP_VIA                                  policy<{'amd64': '-'}>
+CONFIG_AHCI_BRCM                                policy<{'arm64': '-'}>
+CONFIG_AHCI_IMX                                 policy<{'arm64': '-'}>
+CONFIG_AHCI_MTK                                 policy<{'arm64': '-'}>
+CONFIG_AHCI_MVEBU                               policy<{'arm64': '-'}>
+CONFIG_AHCI_QORIQ                               policy<{'arm64': 'n'}>
+CONFIG_AHCI_SUNXI                               policy<{'arm64': '-'}>
+CONFIG_AHCI_TEGRA                               policy<{'arm64': 'n'}>
+CONFIG_AIC7XXX_CMDS_PER_DEVICE                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AIC7XXX_DEBUG_ENABLE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AIC7XXX_DEBUG_MASK                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AIC7XXX_REG_PRETTY_PRINT                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AIC7XXX_RESET_DELAY_MS                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AIC94XX_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AIRO                                     policy<{'amd64': '-'}>
+CONFIG_AIRO_CS                                  policy<{'amd64': '-'}>
+CONFIG_AIX_PARTITION                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AK09911                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AK8974                                   policy<{'arm64': '-'}>
+CONFIG_AK8975                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AL3010                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AL3320A                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ALIENWARE_WMI                            policy<{'amd64': '-'}>
+CONFIG_ALIM1535_WDT                             policy<{'amd64': 'n'}>
+CONFIG_ALIM7101_WDT                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ALTERA_FREEZE_BRIDGE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ALTERA_MBOX                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ALTERA_MSGDMA                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ALTERA_PR_IP_CORE                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ALTERA_PR_IP_CORE_PLAT                   policy<{'arm64': '-'}>
+CONFIG_ALTERA_STAPL                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ALTERA_TSE                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AL_FIC                                   policy<{'arm64': 'n'}>
+CONFIG_AM2315                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AMBA_PL08X                               policy<{'arm64': 'n'}>
+CONFIG_AMDTEE                                   policy<{'amd64': '-'}>
+CONFIG_AMD_MEM_ENCRYPT                          policy<{'amd64': 'n'}>
+CONFIG_AMD_MEM_ENCRYPT_ACTIVE_BY_DEFAULT        policy<{'amd64': '-'}>
+CONFIG_AMD_PMC                                  policy<{'amd64': 'n'}>
+CONFIG_AMD_PTDMA                                policy<{'amd64': 'n'}>
+CONFIG_AMD_SFH_HID                              policy<{'amd64': 'n'}>
+CONFIG_AMD_XGBE                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AMD_XGBE_DCB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AMD_XGBE_HAVE_ECC                        policy<{'amd64': '-'}>
+CONFIG_AMIGA_PARTITION                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AMILO_RFKILL                             policy<{'amd64': '-'}>
+CONFIG_AMLOGIC_THERMAL                          policy<{'arm64': '-'}>
+CONFIG_ANDROID                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ANDROID_BINDERFS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ANDROID_BINDER_DEVICES                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ANDROID_BINDER_IPC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ANDROID_BINDER_IPC_SELFTEST              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_APDS9300                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_APDS9802ALS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_APDS9960                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_APPLE_AIC                                policy<{'arm64': '-'}>
+CONFIG_APPLE_DART                               policy<{'arm64': '-'}>
+CONFIG_APPLE_GMUX                               policy<{'amd64': '-'}>
+CONFIG_APPLE_MFI_FASTCHARGE                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_APPLE_PROPERTIES                         policy<{'amd64': 'n'}>
+CONFIG_APPLICOM                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_APQ_GCC_8084                             policy<{'arm64': '-'}>
+CONFIG_APQ_MMCC_8084                            policy<{'arm64': '-'}>
+CONFIG_AQTION                                   policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_AQUANTIA_PHY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AR5523                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCH_ACTIONS                             policy<{'arm64': 'n'}>
+CONFIG_ARCH_APPLE                               policy<{'arm64': 'n'}>
+CONFIG_ARCH_BCM4908                             policy<{'arm64': 'n'}>
+CONFIG_ARCH_BERLIN                              policy<{'arm64': 'n'}>
+CONFIG_ARCH_BITMAIN                             policy<{'arm64': 'n'}>
+CONFIG_ARCH_BRCMSTB                             policy<{'arm64': 'n'}>
+CONFIG_ARCH_HAS_CC_PLATFORM                     policy<{'amd64': '-'}>
+CONFIG_ARCH_HAS_EARLY_DEBUG                     policy<{'amd64': '-'}>
+CONFIG_ARCH_HAS_FORCE_DMA_UNENCRYPTED           policy<{'amd64': '-'}>
+CONFIG_ARCH_HAS_PMEM_API                        policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_ARCH_HAS_RESTRICTED_VIRTIO_MEMORY_ACCESS policy<{'amd64': '-'}>
+CONFIG_ARCH_HAS_UACCESS_FLUSHCACHE              policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_ARCH_HIBERNATION_HEADER                  policy<{'amd64': '-'}>
+CONFIG_ARCH_HISI                                policy<{'arm64': 'n'}>
+CONFIG_ARCH_INLINE_READ_LOCK                    policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_READ_LOCK_BH                 policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_READ_LOCK_IRQ                policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_READ_LOCK_IRQSAVE            policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_READ_UNLOCK                  policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_READ_UNLOCK_BH               policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_READ_UNLOCK_IRQ              policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_READ_UNLOCK_IRQRESTORE       policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_LOCK                    policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_LOCK_BH                 policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_LOCK_IRQ                policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_LOCK_IRQSAVE            policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_TRYLOCK                 policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_TRYLOCK_BH              policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_UNLOCK                  policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_UNLOCK_BH               policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_UNLOCK_IRQ              policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_SPIN_UNLOCK_IRQRESTORE       policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_WRITE_LOCK                   policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_WRITE_LOCK_BH                policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_WRITE_LOCK_IRQ               policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_WRITE_LOCK_IRQSAVE           policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_WRITE_UNLOCK                 policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_WRITE_UNLOCK_BH              policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_WRITE_UNLOCK_IRQ             policy<{'arm64': '-'}>
+CONFIG_ARCH_INLINE_WRITE_UNLOCK_IRQRESTORE      policy<{'arm64': '-'}>
+CONFIG_ARCH_INTEL_SOCFPGA                       policy<{'arm64': 'n'}>
+CONFIG_ARCH_K3                                  policy<{'arm64': 'n'}>
+CONFIG_ARCH_KEEMBAY                             policy<{'arm64': 'n'}>
+CONFIG_ARCH_LAYERSCAPE                          policy<{'arm64': 'n'}>
+CONFIG_ARCH_LG1K                                policy<{'arm64': 'n'}>
+CONFIG_ARCH_MEDIATEK                            policy<{'arm64': 'n'}>
+CONFIG_ARCH_MESON                               policy<{'arm64': 'n'}>
+CONFIG_ARCH_MVEBU                               policy<{'arm64': 'n'}>
+CONFIG_ARCH_MXC                                 policy<{'arm64': 'n'}>
+CONFIG_ARCH_QCOM                                policy<{'arm64': 'n'}>
+CONFIG_ARCH_R8A774A1                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A774B1                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A774C0                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A774E1                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77950                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77951                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77960                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77961                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77965                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77970                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77980                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77990                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A77995                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R8A779A0                            policy<{'arm64': '-'}>
+CONFIG_ARCH_R9A07G044                           policy<{'arm64': '-'}>
+CONFIG_ARCH_RCAR_GEN3                           policy<{'arm64': '-'}>
+CONFIG_ARCH_REALTEK                             policy<{'arm64': 'n'}>
+CONFIG_ARCH_RENESAS                             policy<{'arm64': 'n'}>
+CONFIG_ARCH_S32                                 policy<{'arm64': 'n'}>
+CONFIG_ARCH_SPARX5                              policy<{'arm64': 'n'}>
+CONFIG_ARCH_SUNXI                               policy<{'arm64': 'n'}>
+CONFIG_ARCH_SUPPORTS_KMAP_LOCAL_FORCE_MAP       policy<{'amd64': 'y'}>
+CONFIG_ARCH_SUPPORTS_SHADOW_CALL_STACK          policy<{'arm64': '-'}>
+CONFIG_ARCH_SYNQUACER                           policy<{'arm64': 'n'}>
+CONFIG_ARCH_TEGRA_186_SOC                       policy<{'arm64': 'n'}>
+CONFIG_ARCH_TEGRA_194_SOC                       policy<{'arm64': 'n'}>
+CONFIG_ARCH_TEGRA_210_SOC                       policy<{'arm64': 'n'}>
+CONFIG_ARCH_TEGRA_234_SOC                       policy<{'arm64': 'n'}>
+CONFIG_ARCH_THUNDER2                            policy<{'arm64': 'n'}>
+CONFIG_ARCH_VISCONTI                            policy<{'arm64': 'n'}>
+CONFIG_ARCH_ZYNQMP                              policy<{'arm64': 'n'}>
+CONFIG_ARCNET                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ARCNET_1051                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCNET_1201                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCNET_CAP                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCNET_COM20020                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCNET_COM20020_CS                       policy<{'amd64': '-'}>
+CONFIG_ARCNET_COM20020_PCI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCNET_COM90xx                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCNET_COM90xxIO                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCNET_RAW                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCNET_RIM_I                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ARCX_ANYBUS_CONTROLLER                   policy<{'arm64': '-'}>
+CONFIG_ARC_EMAC_CORE                            policy<{'arm64': '-'}>
+CONFIG_ARM64_DEBUG_PRIORITY_MASKING             policy<{'arm64': '-'}>
+CONFIG_ARM64_PMEM                               policy<{'arm64': 'n'}>
+CONFIG_ARM64_PSEUDO_NMI                         policy<{'arm64': 'n'}>
+CONFIG_ARM64_SW_TTBR0_PAN                       policy<{'arm64': 'n'}>
+CONFIG_ARMADA_37XX_CLK                          policy<{'arm64': '-'}>
+CONFIG_ARMADA_37XX_RWTM_MBOX                    policy<{'arm64': '-'}>
+CONFIG_ARMADA_37XX_WATCHDOG                     policy<{'arm64': '-'}>
+CONFIG_ARMADA_AP806_SYSCON                      policy<{'arm64': '-'}>
+CONFIG_ARMADA_AP_CPU_CLK                        policy<{'arm64': '-'}>
+CONFIG_ARMADA_AP_CP_HELPER                      policy<{'arm64': '-'}>
+CONFIG_ARMADA_CP110_SYSCON                      policy<{'arm64': '-'}>
+CONFIG_ARMADA_THERMAL                           policy<{'arm64': '-'}>
+CONFIG_ARM_ALLWINNER_SUN50I_CPUFREQ_NVMEM       policy<{'arm64': '-'}>
+CONFIG_ARM_ARMADA_37XX_CPUFREQ                  policy<{'arm64': '-'}>
+CONFIG_ARM_ARMADA_8K_CPUFREQ                    policy<{'arm64': '-'}>
+CONFIG_ARM_BRCMSTB_AVS_CPUFREQ                  policy<{'arm64': '-'}>
+CONFIG_ARM_CCI                                  policy<{'arm64': '-'}>
+CONFIG_ARM_CCI400_COMMON                        policy<{'arm64': '-'}>
+CONFIG_ARM_CCI400_PMU                           policy<{'arm64': '-'}>
+CONFIG_ARM_CCI5xx_PMU                           policy<{'arm64': '-'}>
+CONFIG_ARM_CCI_PMU                              policy<{'arm64': 'n'}>
+CONFIG_ARM_CCN                                  policy<{'arm64': 'n'}>
+CONFIG_ARM_CMN                                  policy<{'arm64': 'n'}>
+CONFIG_ARM_CPUIDLE                              policy<{'arm64': 'n'}>
+CONFIG_ARM_DMC620_PMU                           policy<{'arm64': 'n'}>
+CONFIG_ARM_DSU_PMU                              policy<{'arm64': 'n'}>
+CONFIG_ARM_FFA_SMCCC                            policy<{'arm64': '-'}>
+CONFIG_ARM_FFA_TRANSPORT                        policy<{'arm64': 'n'}>
+CONFIG_ARM_GIC_V3_ITS_FSL_MC                    policy<{'arm64': '-'}>
+CONFIG_ARM_IMX6Q_CPUFREQ                        policy<{'arm64': '-'}>
+CONFIG_ARM_IMX8M_DDRC_DEVFREQ                   policy<{'arm64': '-'}>
+CONFIG_ARM_IMX_BUS_DEVFREQ                      policy<{'arm64': '-'}>
+CONFIG_ARM_IMX_CPUFREQ_DT                       policy<{'arm64': '-'}>
+CONFIG_ARM_MEDIATEK_CPUFREQ                     policy<{'arm64': '-'}>
+CONFIG_ARM_MEDIATEK_CPUFREQ_HW                  policy<{'arm64': '-'}>
+CONFIG_ARM_MHU                                  policy<{'arm64': 'n'}>
+CONFIG_ARM_MHU_V2                               policy<{'arm64': 'n'}>
+CONFIG_ARM_PL172_MPMC                           policy<{'arm64': '-'}>
+CONFIG_ARM_PSCI_CPUIDLE                         policy<{'arm64': 'n'}>
+CONFIG_ARM_PSCI_CPUIDLE_DOMAIN                  policy<{'arm64': '-'}>
+CONFIG_ARM_QCOM_CPUFREQ_HW                      policy<{'arm64': '-'}>
+CONFIG_ARM_QCOM_CPUFREQ_NVMEM                   policy<{'arm64': '-'}>
+CONFIG_ARM_RASPBERRYPI_CPUFREQ                  policy<{'arm64': '-'}>
+CONFIG_ARM_RK3399_DMC_DEVFREQ                   policy<{'arm64': '-'}>
+CONFIG_ARM_SBSA_WATCHDOG                        policy<{'arm64': 'n'}>
+CONFIG_ARM_SCMI_CPUFREQ                         policy<{'arm64': '-'}>
+CONFIG_ARM_SCMI_HAVE_MSG                        policy<{'arm64': '-'}>
+CONFIG_ARM_SCMI_HAVE_SHMEM                      policy<{'arm64': '-'}>
+CONFIG_ARM_SCMI_HAVE_TRANSPORT                  policy<{'arm64': '-'}>
+CONFIG_ARM_SCMI_POWER_DOMAIN                    policy<{'arm64': '-'}>
+CONFIG_ARM_SCMI_PROTOCOL                        policy<{'arm64': 'n'}>
+CONFIG_ARM_SCMI_TRANSPORT_MAILBOX               policy<{'arm64': '-'}>
+CONFIG_ARM_SCMI_TRANSPORT_SMC                   policy<{'arm64': '-'}>
+CONFIG_ARM_SCMI_TRANSPORT_VIRTIO                policy<{'arm64': '-'}>
+CONFIG_ARM_SCPI_CPUFREQ                         policy<{'arm64': '-'}>
+CONFIG_ARM_SCPI_POWER_DOMAIN                    policy<{'arm64': '-'}>
+CONFIG_ARM_SCPI_PROTOCOL                        policy<{'arm64': 'n'}>
+CONFIG_ARM_SDE_INTERFACE                        policy<{'arm64': '-'}>
+CONFIG_ARM_SMC_WATCHDOG                         policy<{'arm64': 'n'}>
+CONFIG_ARM_SMMU_QCOM                            policy<{'arm64': '-'}>
+CONFIG_ARM_SMMU_V3_PMU                          policy<{'arm64': 'n'}>
+CONFIG_ARM_SMMU_V3_SVA                          policy<{'arm64': 'n'}>
+CONFIG_ARM_SP805_WATCHDOG                       policy<{'arm64': 'n'}>
+CONFIG_ARM_SPE_PMU                              policy<{'arm64': 'n'}>
+CONFIG_ARM_TEGRA186_CPUFREQ                     policy<{'arm64': '-'}>
+CONFIG_ARM_TEGRA194_CPUFREQ                     policy<{'arm64': '-'}>
+CONFIG_ARM_TEGRA_DEVFREQ                        policy<{'arm64': '-'}>
+CONFIG_AS3935                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AS73211                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ASHMEM                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ASM_MODVERSIONS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ASN1_ENCODER                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_ASUS_LAPTOP                              policy<{'amd64': '-'}>
+CONFIG_ASUS_NB_WMI                              policy<{'amd64': '-'}>
+CONFIG_ASUS_WIRELESS                            policy<{'amd64': 'n'}>
+CONFIG_ASUS_WMI                                 policy<{'amd64': '-'}>
+CONFIG_ASYMMETRIC_TPM_KEY_SUBTYPE               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ASYNC_TX_DMA                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AT76C50X_USB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATALK                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ATARI_PARTITION                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ATA_GENERIC                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ATH10K                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH10K_AHB                               policy<{'arm64': '-'}>
+CONFIG_ATH10K_CE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH10K_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH10K_DEBUGFS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH10K_PCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH10K_SDIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH10K_SNOC                              policy<{'arm64': '-'}>
+CONFIG_ATH10K_SPECTRAL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH10K_TRACING                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH10K_USB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH11K                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH11K_AHB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH11K_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH11K_DEBUGFS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH11K_PCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH11K_SPECTRAL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH11K_TRACING                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH5K                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH5K_DEBUG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH5K_PCI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH5K_TRACER                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH6KL                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH6KL_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH6KL_SDIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH6KL_TRACING                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH6KL_USB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_AHB                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_BTCOEX_SUPPORT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_CHANNEL_CONTEXT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_COMMON                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_COMMON_DEBUG                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_COMMON_SPECTRAL                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_DEBUGFS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_DYNACK                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_HTC                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_HTC_DEBUGFS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_HW                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_HWRNG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_PCI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_PCI_NO_EEPROM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_PCOEM                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_RFKILL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_STATION_STATISTICS                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH9K_WOW                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH_COMMON                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATH_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATLAS_EZO_SENSOR                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATLAS_PH_SENSOR                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ATMEL                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_AMBASSADOR                           policy<{'amd64': '-'}>
+CONFIG_ATM_AMBASSADOR_DEBUG                     policy<{'amd64': '-'}>
+CONFIG_ATM_BR2684                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_BR2684_IPFILTER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_CLIP                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_CLIP_NO_ICMP                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_DRIVERS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_DUMMY                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_ENI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_ENI_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_ENI_TUNE_BURST                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_FIRESTREAM                           policy<{'amd64': '-'}>
+CONFIG_ATM_FORE200E                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_FORE200E_DEBUG                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_FORE200E_TX_RETRY                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_FORE200E_USE_TASKLET                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_HE                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_HE_USE_SUNI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_HORIZON                              policy<{'amd64': '-'}>
+CONFIG_ATM_HORIZON_DEBUG                        policy<{'amd64': '-'}>
+CONFIG_ATM_IA                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_IA_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_IDT77252                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_IDT77252_DEBUG                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_IDT77252_RCV_ALL                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_IDT77252_USE_SUNI                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_LANAI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_LANE                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_MPOA                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_NICSTAR                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_NICSTAR_USE_IDT77105                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_NICSTAR_USE_SUNI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_SOLOS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_TCP                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ATM_ZATM                                 policy<{'amd64': '-'}>
+CONFIG_ATM_ZATM_DEBUG                           policy<{'amd64': '-'}>
+CONFIG_ATP                                      policy<{'amd64': '-'}>
+CONFIG_AUXDISPLAY                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_AX25                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AX25_DAMA_SLAVE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AXI_DMAC                                 policy<{'arm64': '-'}>
+CONFIG_AXP20X_ADC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AXP20X_POWER                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AXP288_ADC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_AXP288_CHARGER                           policy<{'amd64': '-'}>
+CONFIG_AXP288_FUEL_GAUGE                        policy<{'amd64': '-'}>
+CONFIG_B43                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_DEBUG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_DMA                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_DMA_AND_PIO_MODE               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_DMA_MODE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_HWRNG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_LEDS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_PCICORE_AUTOSELECT             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_PCI_AUTOSELECT                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_PIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43LEGACY_PIO_MODE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_BCMA                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_BCMA_PIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_BUSES_BCMA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_BUSES_BCMA_AND_SSB                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_BUSES_SSB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_HWRNG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_LEDS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_PCICORE_AUTOSELECT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_PCI_AUTOSELECT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_PHY_G                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_PHY_HT                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_PHY_LP                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_PHY_N                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_PIO                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_SDIO                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B43_SSB                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B53                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B53_MDIO_DRIVER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B53_MMAP_DRIVER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B53_SERDES                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B53_SPI_DRIVER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_B53_SRAB_DRIVER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_88PM860X                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_AAT2870                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_ADP5520                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_ADP8860                        policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_ADP8870                        policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_APPLE                          policy<{'amd64': '-'}>
+CONFIG_BACKLIGHT_ARCXCNN                        policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_AS3711                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_BD6107                         policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_CARILLO_RANCH                  policy<{'amd64': '-'}>
+CONFIG_BACKLIGHT_CLASS_DEVICE                   policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_BACKLIGHT_DA903X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_DA9052                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_GPIO                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_KTD253                         policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_LED                            policy<{'arm64': 'n'}>
+CONFIG_BACKLIGHT_LM3533                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_LM3630A                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_LM3639                         policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_LP855X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_LP8788                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_LV5207LP                       policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_MAX8925                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_PANDORA                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_PCF50633                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_PWM                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_QCOM_WLED                      policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_BACKLIGHT_RAVE_SP                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_RT4831                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_SAHARA                         policy<{'amd64': '-'}>
+CONFIG_BACKLIGHT_SKY81452                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BACKLIGHT_TPS65217                       policy<{'arm64': '-'}>
+CONFIG_BACKLIGHT_WM831X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BAREUDP                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATMAN_ADV                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATMAN_ADV_BATMAN_V                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATMAN_ADV_BLA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATMAN_ADV_DAT                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATMAN_ADV_DEBUG                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATMAN_ADV_MCAST                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATMAN_ADV_NC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATMAN_ADV_TRACING                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_88PM860X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_ACT8945A                         policy<{'arm64': '-'}>
+CONFIG_BATTERY_AXP20X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_BQ27XXX                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_BQ27XXX_DT_UPDATES_NVM           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_BQ27XXX_HDQ                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_BQ27XXX_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_CPCAP                            policy<{'arm64': '-'}>
+CONFIG_BATTERY_CW2015                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_DA9030                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_DA9052                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_DA9150                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_DS2760                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_DS2780                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_DS2781                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_DS2782                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_GAUGE_LTC2941                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_GOLDFISH                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_MAX17040                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_MAX17042                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_MAX1721X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_RT5033                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_RX51                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_SBS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BATTERY_SURFACE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BATTERY_TWL4030_MADC                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BAYCOM_PAR                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BAYCOM_SER_FDX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BAYCOM_SER_HDX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCACHE_ASYNC_REGISTRATION                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BCH                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCM2711_THERMAL                          policy<{'arm64': 'n'}>
+CONFIG_BCM2835_MBOX                             policy<{'arm64': 'n'}>
+CONFIG_BCM2835_THERMAL                          policy<{'arm64': 'n'}>
+CONFIG_BCM2835_VCHIQ                            policy<{'arm64': '-'}>
+CONFIG_BCM2835_VCHIQ_MMAL                       policy<{'arm64': '-'}>
+CONFIG_BCM2835_WDT                              policy<{'arm64': 'n'}>
+CONFIG_BCM4908_ENET                             policy<{'arm64': '-'}>
+CONFIG_BCM54140_PHY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BCM7038_L1_IRQ                           policy<{'arm64': '-'}>
+CONFIG_BCM7038_WDT                              policy<{'arm64': '-'}>
+CONFIG_BCM7XXX_PHY                              policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_BCM84881_PHY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BCMA                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BCMA_BLOCKIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMA_DEBUG                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMA_DRIVER_GMAC_CMN                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMA_DRIVER_GPIO                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMA_DRIVER_PCI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMA_HOST_PCI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMA_HOST_PCI_POSSIBLE                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMA_HOST_SOC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMA_SFLASH                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BCMGENET                                 policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_BCM_CYGNUS_PHY                           policy<{'arm64': 'n'}>
+CONFIG_BCM_IPROC_ADC                            policy<{'arm64': '-'}>
+CONFIG_BCM_KONA_USB2_PHY                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BCM_NS_THERMAL                           policy<{'arm64': 'y'}>
+CONFIG_BCM_PDC_MBOX                             policy<{'arm64': 'n'}>
+CONFIG_BCM_PMB                                  policy<{'arm64': '-'}>
+CONFIG_BCM_SR_THERMAL                           policy<{'arm64': 'y'}>
+CONFIG_BCM_VIDEOCORE                            policy<{'arm64': '-'}>
+CONFIG_BCM_VK                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BCM_VK_TTY                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BD957XMUF_WATCHDOG                       policy<{'arm64': '-'}>
+CONFIG_BE2ISCSI                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BEFS_DEBUG                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BEFS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BERLIN2_ADC                              policy<{'arm64': '-'}>
+CONFIG_BFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BH1750                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BH1780                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_CGROUP_FC_APPID                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_CGROUP_IOCOST                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BLK_CGROUP_IOPRIO                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BLK_DEBUG_FS_ZONED                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_DEV_CRYPTOLOOP                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BLK_DEV_FD                               policy<{'amd64': 'n'}>
+CONFIG_BLK_DEV_FD_RAWCMD                        policy<{'amd64': '-'}>
+CONFIG_BLK_DEV_NULL_BLK                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BLK_DEV_PMEM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_DEV_RNBD                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_DEV_RNBD_CLIENT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_DEV_RNBD_SERVER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_DEV_RSXX                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BLK_DEV_ZONED                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BLK_INLINE_ENCRYPTION                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BLK_INLINE_ENCRYPTION_FALLBACK           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_MQ_RDMA                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_RQ_ALLOC_TIME                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BLK_SED_OPAL                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BMA220                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMA400                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMA400_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMA400_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMC150_ACCEL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMC150_ACCEL_I2C                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMC150_ACCEL_SPI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMC150_MAGN                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMC150_MAGN_I2C                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMC150_MAGN_SPI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BME680                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BME680_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BME680_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMG160                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMG160_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMG160_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMI088_ACCEL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMI088_ACCEL_SPI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMI160                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMI160_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMI160_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMP280                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMP280_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BMP280_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BNXT_DCB                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BOARD_TPCI200                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BOOTPARAM_HARDLOCKUP_PANIC               policy<{'amd64': 'y'}>
+CONFIG_BOOTPARAM_HARDLOCKUP_PANIC_VALUE         policy<{'amd64': '1'}>
+CONFIG_BOOTPARAM_SOFTLOCKUP_PANIC               policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_BOOTPARAM_SOFTLOCKUP_PANIC_VALUE         policy<{'amd64': '1', 'arm64': '1'}>
+CONFIG_BOOTTIME_TRACING                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BOOT_CONFIG                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BPFILTER                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BPFILTER_UMH                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BPF_KPROBE_OVERRIDE                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BPF_STREAM_PARSER                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BPQETHER                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMDBG                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMFMAC                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMFMAC_PCIE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMFMAC_PROTO_BCDC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMFMAC_PROTO_MSGBUF                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMFMAC_SDIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMFMAC_USB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMSMAC                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCMSTB_DPFE                             policy<{'arm64': '-'}>
+CONFIG_BRCMSTB_GISB_ARB                         policy<{'arm64': 'n'}>
+CONFIG_BRCMSTB_PM                               policy<{'arm64': '-'}>
+CONFIG_BRCMSTB_THERMAL                          policy<{'arm64': '-'}>
+CONFIG_BRCMUTIL                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCM_TRACING                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BRCM_USB_PINMAP                          policy<{'arm64': '-'}>
+CONFIG_BRIDGE_CFM                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BRIDGE_MRP                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BT                                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_BTT                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_6LOWPAN                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_AOSPEXT                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_ATH3K                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_BCM                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_BNEP                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_BNEP_MC_FILTER                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_BNEP_PROTO_FILTER                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_BREDR                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_CMTP                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_DEBUGFS                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBCM203X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBFUSB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBLUECARD                           policy<{'amd64': '-'}>
+CONFIG_BT_HCIBPA10X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBT3C                               policy<{'amd64': '-'}>
+CONFIG_BT_HCIBTSDIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBTUSB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBTUSB_AUTOSUSPEND                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBTUSB_BCM                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBTUSB_MTK                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIBTUSB_RTL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIDTL1                               policy<{'amd64': '-'}>
+CONFIG_BT_HCIRSI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_3WIRE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_AG6XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_ATH3K                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_BCM                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_BCSP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_H4                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_INTEL                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_LL                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_MRVL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_NOKIA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_QCA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_RTL                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIUART_SERDEV                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HCIVHCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HIDP                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_HS                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_INTEL                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_LE                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_LEDS                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_MRVL                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_MRVL_SDIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_MSFTEXT                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_MTKSDIO                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_MTKUART                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_QCA                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_QCOMSMD                               policy<{'arm64': '-'}>
+CONFIG_BT_RFCOMM                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_RFCOMM_TTY                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_RTL                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_SELFTEST                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BT_VIRTIO                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_BUILD_BIN2C                              policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_BXT_WC_PMIC_OPREGION                     policy<{'amd64': '-'}>
+CONFIG_BYTCRC_PMIC_OPREGION                     policy<{'amd64': '-'}>
+CONFIG_C2PORT                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_C2PORT_DURAMAR_2150                      policy<{'amd64': '-'}>
+CONFIG_CADENCE_WATCHDOG                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CAIF                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CAIF_DEBUG                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAIF_DRIVERS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAIF_NETDEV                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAIF_TTY                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAIF_USB                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAIF_VIRTIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CAN_8DEV_USB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_BCM                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_CALC_BITTIMING                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_CC770                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_CC770_ISA                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_CC770_PLATFORM                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_C_CAN                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_C_CAN_PCI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_C_CAN_PLATFORM                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_DEBUG_DEVICES                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_DEV                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_EMS_PCI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_EMS_PCMCIA                           policy<{'amd64': '-'}>
+CONFIG_CAN_EMS_USB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_ESD_USB2                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_ETAS_ES58X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_F81601                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_F81604                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_FLEXCAN                              policy<{'arm64': '-'}>
+CONFIG_CAN_GRCAN                                policy<{'arm64': '-'}>
+CONFIG_CAN_GS_USB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_GW                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_HI311X                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_IFI_CANFD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_ISOTP                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_J1939                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_JANZ_ICAN3                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_KVASER_PCI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_KVASER_PCIEFD                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_KVASER_USB                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_MCBA_USB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_MCP251X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_MCP251XFD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_MCP251XFD_SANITY                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_M_CAN                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_M_CAN_PCI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_M_CAN_PLATFORM                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_M_CAN_TCAN4X5X                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_PEAK_PCI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_PEAK_PCIEC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_PEAK_PCIEFD                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_PEAK_PCMCIA                          policy<{'amd64': '-'}>
+CONFIG_CAN_PEAK_USB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_PLX_PCI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_RAW                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_RCAR                                 policy<{'arm64': '-'}>
+CONFIG_CAN_RCAR_CANFD                           policy<{'arm64': '-'}>
+CONFIG_CAN_SJA1000                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_SJA1000_ISA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_SJA1000_PLATFORM                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_SLCAN                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_SOFTING                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_SOFTING_CS                           policy<{'amd64': '-'}>
+CONFIG_CAN_UCAN                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_VCAN                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_VXCAN                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAN_XILINXCAN                            policy<{'arm64': '-'}>
+CONFIG_CAPI_TRACE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CARDBUS                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CARDMAN_4000                             policy<{'amd64': '-'}>
+CONFIG_CARDMAN_4040                             policy<{'amd64': '-'}>
+CONFIG_CARL9170                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CARL9170_DEBUGFS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CARL9170_HWRNG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CARL9170_LEDS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CARL9170_WPC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CARMINE_DRAM_CUSTOM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CASSINI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CAVIUM_CPT                               policy<{'arm64': 'n'}>
+CONFIG_CAVIUM_PTP                               policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_CB710_CORE                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CB710_DEBUG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CB710_DEBUG_ASSUMPTIONS                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CC10001_ADC                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CCS811                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CC_CAN_LINK                              policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_CC_CAN_LINK_STATIC                       policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_BARE           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CC_HAS_UBSAN_BOUNDS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CC_HAVE_SHADOW_CALL_STACK                policy<{'arm64': '-'}>
+CONFIG_CDNS_I3C_MASTER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CDROM_PKTCDVD                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CDROM_PKTCDVD_BUFFERS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CDROM_PKTCDVD_WCACHE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CEC_CH7322                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CEC_CORE                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CEC_CROS_EC                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CEC_MESON_AO                             policy<{'arm64': '-'}>
+CONFIG_CEC_MESON_G12A_AO                        policy<{'arm64': '-'}>
+CONFIG_CEC_NOTIFIER                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CEC_PIN                                  policy<{'arm64': '-'}>
+CONFIG_CEC_PIN_ERROR_INJ                        policy<{'arm64': '-'}>
+CONFIG_CEC_SECO                                 policy<{'amd64': '-'}>
+CONFIG_CEC_SECO_RC                              policy<{'amd64': '-'}>
+CONFIG_CEC_TEGRA                                policy<{'arm64': '-'}>
+CONFIG_CEPH_FS_SECURITY_LABEL                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CFAG12864B                               policy<{'amd64': '-'}>
+CONFIG_CFAG12864B_RATE                          policy<{'amd64': '-'}>
+CONFIG_CFG80211                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_CERTIFICATION_ONUS              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_CRDA_SUPPORT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_DEBUGFS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_DEFAULT_PS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_DEVELOPER_WARNINGS              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_REQUIRE_SIGNED_REGDB            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_USE_KERNEL_REGDB_KEYS           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_WEXT                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CFG80211_WEXT_EXPORT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CGROUP_MISC                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CGROUP_RDMA                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_88PM860X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_ADP5061                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_AXP20X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_BD99954                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_BQ2415X                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_BQ24190                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_CHARGER_BQ24257                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_BQ24735                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_BQ2515X                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_BQ256XX                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_BQ25890                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_BQ25980                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_CPCAP                            policy<{'arm64': '-'}>
+CONFIG_CHARGER_CROS_PCHG                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_CROS_USBPD                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_DA9150                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_DETECTOR_MAX14656                policy<{'arm64': 'n'}>
+CONFIG_CHARGER_GPIO                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_ISP1704                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_LP8727                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_LP8788                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_LT3651                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_LTC4162L                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_MANAGER                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_MAX14577                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_MAX77650                         policy<{'arm64': '-'}>
+CONFIG_CHARGER_MAX77693                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_MAX8903                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_MAX8997                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_MAX8998                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_MP2629                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_MT6360                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_PCF50633                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_QCOM_SMBB                        policy<{'arm64': '-'}>
+CONFIG_CHARGER_RT9455                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_SBS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_SC2731                           policy<{'arm64': '-'}>
+CONFIG_CHARGER_SMB347                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHARGER_SURFACE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_TPS65090                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_TPS65217                         policy<{'arm64': '-'}>
+CONFIG_CHARGER_TWL4030                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARGER_UCS1002                          policy<{'arm64': 'n'}>
+CONFIG_CHARGER_WILCO                            policy<{'amd64': '-'}>
+CONFIG_CHARLCD                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARLCD_BL_FLASH                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARLCD_BL_OFF                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHARLCD_BL_ON                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHELSIO_IPSEC_INLINE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHELSIO_LIB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHELSIO_T4_DCB                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHELSIO_T4_FCOE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHELSIO_TLS_DEVICE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHROMEOS_LAPTOP                          policy<{'amd64': '-'}>
+CONFIG_CHROMEOS_PSTORE                          policy<{'amd64': '-'}>
+CONFIG_CHROMEOS_TBMC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CHROME_PLATFORMS                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHR_DEV_SCH                              policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_CHR_DEV_ST                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CHTCRC_PMIC_OPREGION                     policy<{'amd64': '-'}>
+CONFIG_CHT_DC_TI_PMIC_OPREGION                  policy<{'amd64': '-'}>
+CONFIG_CHT_WC_PMIC_OPREGION                     policy<{'amd64': '-'}>
+CONFIG_CICADA_PHY                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CIFS_SMB_DIRECT                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CIO2_BRIDGE                              policy<{'amd64': '-'}>
+CONFIG_CIO_DAC                                  policy<{'amd64': '-'}>
+CONFIG_CLK_ACTIONS                              policy<{'arm64': '-'}>
+CONFIG_CLK_BCM2711_DVP                          policy<{'arm64': 'y'}>
+CONFIG_CLK_GFM_LPASS_SM8250                     policy<{'arm64': '-'}>
+CONFIG_CLK_IMX8MM                               policy<{'arm64': '-'}>
+CONFIG_CLK_IMX8MN                               policy<{'arm64': '-'}>
+CONFIG_CLK_IMX8MP                               policy<{'arm64': '-'}>
+CONFIG_CLK_IMX8MQ                               policy<{'arm64': '-'}>
+CONFIG_CLK_IMX8QXP                              policy<{'arm64': '-'}>
+CONFIG_CLK_INTEL_SOCFPGA                        policy<{'arm64': '-'}>
+CONFIG_CLK_INTEL_SOCFPGA64                      policy<{'arm64': '-'}>
+CONFIG_CLK_LS1028A_PLLDIG                       policy<{'arm64': '-'}>
+CONFIG_CLK_OWL_S500                             policy<{'arm64': '-'}>
+CONFIG_CLK_OWL_S700                             policy<{'arm64': '-'}>
+CONFIG_CLK_OWL_S900                             policy<{'arm64': '-'}>
+CONFIG_CLK_QORIQ                                policy<{'arm64': '-'}>
+CONFIG_CLK_R8A774A1                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A774B1                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A774C0                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A774E1                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A7795                              policy<{'arm64': '-'}>
+CONFIG_CLK_R8A77960                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A77961                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A77965                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A77970                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A77980                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A77990                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A77995                             policy<{'arm64': '-'}>
+CONFIG_CLK_R8A779A0                             policy<{'arm64': '-'}>
+CONFIG_CLK_R9A07G044                            policy<{'arm64': '-'}>
+CONFIG_CLK_RASPBERRYPI                          policy<{'arm64': '-'}>
+CONFIG_CLK_RCAR_CPG_LIB                         policy<{'arm64': '-'}>
+CONFIG_CLK_RCAR_GEN3_CPG                        policy<{'arm64': '-'}>
+CONFIG_CLK_RCAR_USB2_CLOCK_SEL                  policy<{'arm64': '-'}>
+CONFIG_CLK_RENESAS                              policy<{'arm64': '-'}>
+CONFIG_CLK_RENESAS_CPG_MSSR                     policy<{'arm64': '-'}>
+CONFIG_CLK_RENESAS_DIV6                         policy<{'arm64': '-'}>
+CONFIG_CLK_RK3568                               policy<{'arm64': 'y'}>
+CONFIG_CLK_RZG2L                                policy<{'arm64': '-'}>
+CONFIG_CLK_SP810                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CLK_SUNXI                                policy<{'arm64': '-'}>
+CONFIG_CLK_SUNXI_CLOCKS                         policy<{'arm64': '-'}>
+CONFIG_CLK_SUNXI_PRCM_SUN6I                     policy<{'arm64': '-'}>
+CONFIG_CLK_SUNXI_PRCM_SUN8I                     policy<{'arm64': '-'}>
+CONFIG_CLK_SUNXI_PRCM_SUN9I                     policy<{'arm64': '-'}>
+CONFIG_CLK_TEGRA_BPMP                           policy<{'arm64': '-'}>
+CONFIG_CLK_TWL6040                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CM32181                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CM3232                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CM3323                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CM3605                                   policy<{'arm64': '-'}>
+CONFIG_CM36651                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CMA_ALIGNMENT                            policy<{'arm64': '-'}>
+CONFIG_CMA_AREAS                                policy<{'arm64': '-'}>
+CONFIG_CMA_DEBUG                                policy<{'arm64': '-'}>
+CONFIG_CMA_DEBUGFS                              policy<{'arm64': '-'}>
+CONFIG_CMA_SIZE_SEL_MAX                         policy<{'arm64': '-'}>
+CONFIG_CMA_SIZE_SEL_MBYTES                      policy<{'arm64': '-'}>
+CONFIG_CMA_SIZE_SEL_MIN                         policy<{'arm64': '-'}>
+CONFIG_CMA_SIZE_SEL_PERCENTAGE                  policy<{'arm64': '-'}>
+CONFIG_CMA_SYSFS                                policy<{'arm64': '-'}>
+CONFIG_CODA_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COMEDI                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COMEDI_8254                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_8255                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_8255_PCI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_8255_SA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_1032                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_1500                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_1516                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_1564                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_16XX                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_2032                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_2200                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_3120                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_3501                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_APCI_3XXX                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADDI_WATCHDOG                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADL_PCI6208                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADL_PCI7X3X                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADL_PCI8164                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADL_PCI9111                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADL_PCI9118                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADQ12B                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADV_PCI1710                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADV_PCI1720                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADV_PCI1723                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADV_PCI1724                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADV_PCI1760                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ADV_PCI_DIO                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AIO_AIO12_8                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AIO_IIRO_16                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_DIO200                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_DIO200_ISA                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_DIO200_PCI                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_PC236                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_PC236_ISA                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_PC236_PCI                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_PC263_ISA                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_PC263_PCI                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_PCI224                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_AMPLC_PCI230                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_BOND                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_C6XDIGIO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_CB_DAS16_CS                       policy<{'amd64': '-'}>
+CONFIG_COMEDI_CB_PCIDAS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_CB_PCIDAS64                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_CB_PCIDDA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_CB_PCIMDAS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_CB_PCIMDDA                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_CONTEC_PCI_DIO                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAC02                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAQBOARD2000                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAS08                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAS08_CS                          policy<{'amd64': '-'}>
+CONFIG_COMEDI_DAS08_ISA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAS08_PCI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAS16                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAS16M1                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAS1800                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAS6402                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DAS800                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DEFAULT_BUF_MAXSIZE_KB            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DEFAULT_BUF_SIZE_KB               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DMM32AT                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DT2801                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DT2811                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DT2814                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DT2815                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DT2817                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DT282X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DT3000                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DT9812                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_DYNA_PCI10XX                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_FL512                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_GSC_HPDI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ICP_MULTI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_II_PCI20KC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ISADMA                            policy<{'amd64': '-'}>
+CONFIG_COMEDI_ISA_DRIVERS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_JR3_PCI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_KCOMEDILIB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_KE_COUNTER                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ME4000                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_ME_DAQ                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_MF6X4                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_MISC_DRIVERS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_MITE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_MPC624                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_MULTIQ3                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_6527                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_65XX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_660X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_670X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_ATMIO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_ATMIO16D                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_AT_A2150                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_AT_AO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_DAQ_700_CS                     policy<{'amd64': '-'}>
+CONFIG_COMEDI_NI_DAQ_DIO24_CS                   policy<{'amd64': '-'}>
+CONFIG_COMEDI_NI_LABPC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_LABPC_CS                       policy<{'amd64': '-'}>
+CONFIG_COMEDI_NI_LABPC_ISA                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_LABPC_ISADMA                   policy<{'amd64': '-'}>
+CONFIG_COMEDI_NI_LABPC_PCI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_MIO_CS                         policy<{'amd64': '-'}>
+CONFIG_COMEDI_NI_PCIDIO                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_PCIMIO                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_ROUTING                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_TIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_TIOCMD                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_NI_USB6501                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PARPORT                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCI_DRIVERS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCL711                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCL724                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCL726                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCL730                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCL812                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCL816                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCL818                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCM3724                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCMAD                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCMCIA_DRIVERS                    policy<{'amd64': '-'}>
+CONFIG_COMEDI_PCMDA12                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCMMIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_PCMUIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_QUATECH_DAQP_CS                   policy<{'amd64': '-'}>
+CONFIG_COMEDI_RTD520                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_RTI800                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_RTI802                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_S526                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_S626                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_TEST                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_TESTS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_TESTS_EXAMPLE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_TESTS_NI_ROUTES                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_USBDUX                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_USBDUXFAST                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_USBDUXSIGMA                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_USB_DRIVERS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMEDI_VMK80XX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMMON_CLK_AXG                           policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_AXG_AUDIO                     policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_AXI_CLKGEN                    policy<{'arm64': 'n'}>
+CONFIG_COMMON_CLK_BD718XX                       policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_BM1880                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_CDCE706                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COMMON_CLK_CDCE925                       policy<{'arm64': 'n'}>
+CONFIG_COMMON_CLK_CS2000_CP                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COMMON_CLK_FIXED_MMIO                    policy<{'arm64': 'n'}>
+CONFIG_COMMON_CLK_FSL_FLEXSPI                   policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_FSL_SAI                       policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_G12A                          policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_GXBB                          policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_HI3516CV300                   policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_HI3519                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_HI3559A                       policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_HI3660                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_HI3670                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_HI3798CV200                   policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_HI6220                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_HI655X                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_LOCHNAGAR                     policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MAX77686                      policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MAX9485                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COMMON_CLK_MEDIATEK                      policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_AO_CLKC                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_CPU_DYNDIV              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_DUALDIV                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_EE_CLKC                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_MPLL                    policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_PHASE                   policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_PLL                     policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_REGMAP                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_SCLK_DIV                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MESON_VID_PLL_DIV             policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT2712                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT2712_BDPSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT2712_IMGSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT2712_JPGDECSYS              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT2712_MFGCFG                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT2712_MMSYS                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT2712_VDECSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT2712_VENCSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_AUDIOSYS               policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_CAMSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_GCESYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_IMGSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_MFGSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_MIPI0ASYS              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_MIPI0BSYS              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_MIPI1ASYS              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_MIPI1BSYS              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_MIPI2ASYS              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_MIPI2BSYS              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_MMSYS                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6765_VCODECSYS              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779_AUDSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779_CAMSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779_IMGSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779_IPESYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779_MFGCFG                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779_MMSYS                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779_VDECSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6779_VENCSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6797                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6797_IMGSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6797_MMSYS                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6797_VDECSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT6797_VENCSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT7622                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT7622_AUDSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT7622_ETHSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT7622_HIFSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8167                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8167_AUDSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8167_IMGSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8167_MFGCFG                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8167_MMSYS                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8167_VDECSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8173                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8173_MMSYS                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_AUDIOSYS               policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_CAMSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_IMGSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_IPU_ADL                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_IPU_CONN               policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_IPU_CORE0              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_IPU_CORE1              policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_MFGCFG                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_MMSYS                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_VDECSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8183_VENCSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_AUDSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_CAMSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_IMGSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_IMP_IIC_WRAP           policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_IPESYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_MDPSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_MFGCFG                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_MMSYS                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_MSDC                   policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_SCP_ADSP               policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_VDECSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8192_VENCSYS                policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8516                        policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_MT8516_AUDSYS                 policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_PALMAS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMMON_CLK_PWM                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMMON_CLK_QCOM                          policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_RK808                         policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_S2MPS11                       policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_SCMI                          policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_SCPI                          policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_SI514                         policy<{'arm64': 'n'}>
+CONFIG_COMMON_CLK_SI5341                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COMMON_CLK_SI5351                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COMMON_CLK_SI544                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COMMON_CLK_SI570                         policy<{'arm64': 'n'}>
+CONFIG_COMMON_CLK_VC5                           policy<{'arm64': 'n'}>
+CONFIG_COMMON_CLK_WM831X                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_COMMON_CLK_XLNX_CLKWZRD                  policy<{'arm64': '-'}>
+CONFIG_COMMON_CLK_ZYNQMP                        policy<{'arm64': '-'}>
+CONFIG_COMMON_RESET_HI3660                      policy<{'arm64': '-'}>
+CONFIG_COMMON_RESET_HI6220                      policy<{'arm64': '-'}>
+CONFIG_COMPAL_LAPTOP                            policy<{'amd64': '-'}>
+CONFIG_COMPAT_NETLINK_MESSAGES                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CONSOLE_POLL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CONTIG_ALLOC                             policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_CORDIC                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CORTINA_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_COUNTER                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CPCAP_ADC                                policy<{'arm64': '-'}>
+CONFIG_CPUMASK_OFFSTACK                         policy<{'amd64': '-'}>
+CONFIG_CPU_IDLE_MULTIPLE_DRIVERS                policy<{'arm64': '-'}>
+CONFIG_CPU_IDLE_THERMAL                         policy<{'arm64': '-'}>
+CONFIG_CRAMFS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRAMFS_BLOCKDEV                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRAMFS_MTD                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRC4                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRC7                                     policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_CRC8                                     policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRC_CCITT                                policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CROSS_MEMORY_ATTACH                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CROS_EC                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_CHARDEV                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_DEBUGFS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_ISHTP                            policy<{'amd64': '-'}>
+CONFIG_CROS_EC_LIGHTBAR                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_LPC                              policy<{'amd64': '-'}>
+CONFIG_CROS_EC_MKBP_PROXIMITY                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_PROTO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_RPMSG                            policy<{'arm64': '-'}>
+CONFIG_CROS_EC_SENSORHUB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_SYSFS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_TYPEC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_EC_VBC                              policy<{'arm64': '-'}>
+CONFIG_CROS_KBD_LED_BACKLIGHT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_USBPD_LOGGER                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CROS_USBPD_NOTIFY                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_842                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_ADIANTUM                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_AEAD                              policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_CRYPTO_AEGIS128                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_AEGIS128_AESNI_SSE2               policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_AEGIS128_SIMD                     policy<{'arm64': '-'}>
+CONFIG_CRYPTO_AES_ARM64                         policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_AES_ARM64_BS                      policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_AES_ARM64_CE                      policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_AES_ARM64_CE_BLK                  policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_AES_ARM64_CE_CCM                  policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_AES_ARM64_NEON_BLK                policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_AES_TI                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_ANUBIS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_ARC4                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_BLOWFISH                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_BLOWFISH_COMMON                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_BLOWFISH_X86_64                   policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_CAMELLIA                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_CAMELLIA_AESNI_AVX2_X86_64        policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_CAMELLIA_AESNI_AVX_X86_64         policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_CAMELLIA_X86_64                   policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_CAST5                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_CAST5_AVX_X86_64                  policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_CAST6                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_CAST6_AVX_X86_64                  policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_CAST_COMMON                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_CFB                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_CHACHA20                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_CHACHA20POLY1305                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_CRC32                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_CRC32C_INTEL                      policy<{'amd64': 'm'}>
+CONFIG_CRYPTO_CRC32_PCLMUL                      policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_CRCT10DIF_ARM64_CE                policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_CRCT10DIF_PCLMUL                  policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_CRYPTD                            policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_CRYPTO_CURVE25519                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DES3_EDE_X86_64                   policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_ALLWINNER                     policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_AMLOGIC_GXL                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_AMLOGIC_GXL_DEBUG             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_DEV_ATMEL_ECC                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_ATMEL_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_DEV_ATMEL_SHA204A                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_CAVIUM_ZIP                    policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_CCP                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_CCP_CRYPTO                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_DEV_CCP_DD                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_DEV_CCP_DEBUGFS                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_DEV_CCREE                         policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_CHELSIO                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_CPT                           policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM                      policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_AHASH_API            policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_AHASH_API_DESC       policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_COMMON               policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_CRYPTO_API           policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_CRYPTO_API_DESC      policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_CRYPTO_API_QI        policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_DEBUG                policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_INTC                 policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_INTC_COUNT_THLD      policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_INTC_TIME_THLD       policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_JR                   policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_PKC_API              policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_RINGSIZE             policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_CAAM_RNG_API              policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_FSL_DPAA2_CAAM                policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_HISI_HPRE                     policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_HISI_QM                       policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_HISI_SEC                      policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_HISI_SEC2                     policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_HISI_TRNG                     policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_HISI_ZIP                      policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_KEEMBAY_OCS_AES_SM4           policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_KEEMBAY_OCS_AES_SM4_CTS       policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_KEEMBAY_OCS_AES_SM4_ECB       policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_KEEMBAY_OCS_HCU               policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_KEEMBAY_OCS_HCU_HMAC_SHA224   policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_MARVELL                       policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_MARVELL_CESA                  policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_MXS_DCP                       policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_NITROX                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_DEV_NITROX_CNN55XX                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_OCTEONTX2_CPT                 policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_OCTEONTX_CPT                  policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_PADLOCK                       policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_PADLOCK_AES                   policy<{'amd64': '-'}>
+CONFIG_CRYPTO_DEV_PADLOCK_SHA                   policy<{'amd64': '-'}>
+CONFIG_CRYPTO_DEV_QAT                           policy<{'amd64': '-'}>
+CONFIG_CRYPTO_DEV_QAT_4XXX                      policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_QAT_C3XXX                     policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_QAT_C3XXXVF                   policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_QAT_C62X                      policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_QAT_C62XVF                    policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_QAT_DH895xCC                  policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_QAT_DH895xCCVF                policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_DEV_QCE                           policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCE_AEAD                      policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCE_ENABLE_AEAD               policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCE_ENABLE_ALL                policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCE_ENABLE_SHA                policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCE_ENABLE_SKCIPHER           policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCE_SHA                       policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCE_SKCIPHER                  policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCE_SW_MAX_LEN                policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_QCOM_RNG                      policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SA2UL                         policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SAFEXCEL                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_SAHARA                        policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SP_CCP                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SP_PSP                        policy<{'amd64': '-'}>
+CONFIG_CRYPTO_DEV_SUN4I_SS                      policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN4I_SS_DEBUG                policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN4I_SS_PRNG                 policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_CE                      policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_CE_DEBUG                policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_CE_HASH                 policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_CE_PRNG                 policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_CE_TRNG                 policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_SS                      policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_SS_DEBUG                policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_SS_HASH                 policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_SUN8I_SS_PRNG                 policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DEV_VIRTIO                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DEV_ZYNQMP_AES                    policy<{'arm64': '-'}>
+CONFIG_CRYPTO_DRBG                              policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_DRBG_CTR                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DRBG_HASH                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_DRBG_MENU                         policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_ECB                               policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_ECC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_ECDH                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_ECDSA                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_ECRDSA                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_ENGINE                            policy<{'amd64': '-', 'arm64': 'm'}>
+CONFIG_CRYPTO_FCRYPT                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_FIPS                              policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_CRYPTO_GCM                               policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_GF128MUL                          policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_CRYPTO_GHASH                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_GHASH_ARM64_CE                    policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_GHASH_CLMUL_NI_INTEL              policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_JITTERENTROPY                     policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_KEYWRAP                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_KHAZAD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_LIB_POLY1305_GENERIC              policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_CRYPTO_LIB_SM4                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_LRW                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_LZ4                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_LZ4HC                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_LZO                               policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_MANAGER_DISABLE_TESTS             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_MANAGER_EXTRA_TESTS               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_MD4                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_MICHAEL_MIC                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_NHPOLY1305                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_NHPOLY1305_AVX2                   policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_NHPOLY1305_NEON                   policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_NHPOLY1305_SSE2                   policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_NULL                              policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_OFB                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_PCBC                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_PCRYPT                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_POLY1305                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_RMD160                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_RNG_DEFAULT                       policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_SEED                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_SEQIV                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_SERPENT                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_SERPENT_AVX2_X86_64               policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_SERPENT_AVX_X86_64                policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_SERPENT_SSE2_X86_64               policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_SHA1_ARM64_CE                     policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_SHA256_ARM64                      policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_SHA2_ARM64_CE                     policy<{'arm64': 'y'}>
+CONFIG_CRYPTO_SHA3                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_SHA3_ARM64                        policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_SHA512_ARM64                      policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_SHA512_ARM64_CE                   policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_SHA512_SSSE3                      policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_SIMD                              policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_CRYPTO_SM2                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_SM3                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_SM3_ARM64_CE                      policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_SM4                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_SM4_AESNI_AVX2_X86_64             policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_SM4_AESNI_AVX_X86_64              policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_SM4_ARM64_CE                      policy<{'arm64': 'n'}>
+CONFIG_CRYPTO_STATS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_STREEBOG                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_TEA                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_TEST                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_TWOFISH                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_TWOFISH_AVX_X86_64                policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_TWOFISH_COMMON                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_TWOFISH_X86_64                    policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_TWOFISH_X86_64_3WAY               policy<{'amd64': 'n'}>
+CONFIG_CRYPTO_USER                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_USER_API_AEAD                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_USER_API_RNG                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_USER_API_RNG_CAVP                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CRYPTO_VMAC                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_WP512                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_XCBC                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CRYPTO_XTS                               policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_CRYPTO_ZSTD                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CW1200                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CW1200_WLAN_SDIO                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CW1200_WLAN_SPI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CXD2880_SPI_DRV                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CXL_ACPI                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CXL_BUS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_CXL_MEM                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CXL_MEM_RAW_COMMANDS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CXL_PMEM                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_CX_ECAT                                  policy<{'amd64': 'n'}>
+CONFIG_CYPRESS_FIRMWARE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DA280                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DA311                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DA9052_WATCHDOG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DA9055_WATCHDOG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DA9062_THERMAL                           policy<{'arm64': '-'}>
+CONFIG_DA9062_WATCHDOG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DA9063_WATCHDOG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DA9150_GPADC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DAVICOM_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DAX                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DAX_DRIVER                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DCA                                      policy<{'amd64': 'y'}>
+CONFIG_DE2104X                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DE2104X_DSL                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DE4X5                                    policy<{'amd64': 'n'}>
+CONFIG_DEBUG_INFO_DWARF5                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT       policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_DEBUG_KERNEL_DC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEBUG_KMAP_LOCAL_FORCE_MAP               policy<{'amd64': 'n'}>
+CONFIG_DEBUG_PREEMPT                            policy<{'arm64': 'n'}>
+CONFIG_DEBUG_WX                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DEFAULT_SECURITY_APPARMOR                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEFAULT_SECURITY_SELINUX                 policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_DEFAULT_SECURITY_SMACK                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEFAULT_SECURITY_TOMOYO                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEFXX                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DELL_LAPTOP                              policy<{'amd64': '-'}>
+CONFIG_DELL_RBTN                                policy<{'amd64': '-'}>
+CONFIG_DELL_SMBIOS_WMI                          policy<{'amd64': '-'}>
+CONFIG_DELL_UART_BACKLIGHT                      policy<{'amd64': 'n'}>
+CONFIG_DELL_WMI                                 policy<{'amd64': '-'}>
+CONFIG_DELL_WMI_AIO                             policy<{'amd64': '-'}>
+CONFIG_DELL_WMI_DESCRIPTOR                      policy<{'amd64': '-'}>
+CONFIG_DELL_WMI_LED                             policy<{'amd64': '-'}>
+CONFIG_DELL_WMI_PRIVACY                         policy<{'amd64': '-'}>
+CONFIG_DELL_WMI_SYSMAN                          policy<{'amd64': '-'}>
+CONFIG_DEVFREQ_EVENT_ROCKCHIP_DFI               policy<{'arm64': '-'}>
+CONFIG_DEVFREQ_GOV_PASSIVE                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEVFREQ_GOV_PERFORMANCE                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEVFREQ_GOV_POWERSAVE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEVFREQ_GOV_SIMPLE_ONDEMAND              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEVFREQ_GOV_USERSPACE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEVFREQ_THERMAL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEVICE_PRIVATE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_APPLETALK                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_COREDUMP                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_DAX                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_DAX_HMEM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_DAX_HMEM_DEVICES                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_DAX_KMEM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_DAX_PMEM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_DAX_PMEM_COMPAT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DEV_PAGEMAP_OPS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DHT11                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DLHL60D                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DLN2_ADC                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DM9102                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DMABUF_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMABUF_HEAPS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DMABUF_HEAPS_CMA                         policy<{'arm64': '-'}>
+CONFIG_DMABUF_HEAPS_SYSTEM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMABUF_MOVE_NOTIFY                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMABUF_SELFTESTS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMABUF_SYSFS_STATS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMARD06                                  policy<{'arm64': '-'}>
+CONFIG_DMARD09                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMARD10                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMA_BCM2835                              policy<{'arm64': 'n'}>
+CONFIG_DMA_COHERENT_POOL                        policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_DMA_FENCE_TRACE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMA_PERNUMA_CMA                          policy<{'arm64': '-'}>
+CONFIG_DMA_RESTRICTED_POOL                      policy<{'arm64': 'n'}>
+CONFIG_DMA_SHARED_BUFFER                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DMA_SUN6I                                policy<{'arm64': '-'}>
+CONFIG_DMA_VIRTUAL_CHANNELS                     policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_DM_CLONE                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_DEBUG                                 policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_DM_DELAY                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_EBS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_ERA                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_FLAKEY                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_INTEGRITY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_LOG_USERSPACE                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_LOG_WRITES                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_MULTIPATH_HST                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_MULTIPATH_IOA                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_SWITCH                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_UNSTRIPED                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_VERITY_VERIFY_ROOTHASH_SIG            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_WRITECACHE                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DM_ZONED                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DNET                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DP83640_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DP83822_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DP83848_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DP83867_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DP83869_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DP83TC811_PHY                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DPAA2_CONSOLE                            policy<{'arm64': '-'}>
+CONFIG_DPAA_ERRATUM_A050385                     policy<{'arm64': '-'}>
+CONFIG_DPM_WATCHDOG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DPOT_DAC                                 policy<{'arm64': '-'}>
+CONFIG_DPS310                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DPTF_PCH_FIVR                            policy<{'amd64': '-'}>
+CONFIG_DPTF_POWER                               policy<{'amd64': '-'}>
+CONFIG_DRAGONRISE_FF                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DRM_AMDGPU                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_AMDGPU_SI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_AMDGPU_USERPTR                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_AMD_ACP                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_AMD_DC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_AMD_DC_DCN                           policy<{'amd64': '-'}>
+CONFIG_DRM_AMD_DC_HDCP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_AMD_DC_SI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_AMD_SECURE_DISPLAY                   policy<{'amd64': '-'}>
+CONFIG_DRM_ANALOGIX_ANX6345                     policy<{'arm64': '-'}>
+CONFIG_DRM_ANALOGIX_ANX7625                     policy<{'arm64': '-'}>
+CONFIG_DRM_ANALOGIX_ANX78XX                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_ANALOGIX_DP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_ARCPGU                               policy<{'arm64': '-'}>
+CONFIG_DRM_AST                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_BOCHS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_BRIDGE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_CDNS_DSI                             policy<{'arm64': '-'}>
+CONFIG_DRM_CDNS_MHDP8546                        policy<{'arm64': '-'}>
+CONFIG_DRM_CDNS_MHDP8546_J721E                  policy<{'arm64': '-'}>
+CONFIG_DRM_CHIPONE_ICN6211                      policy<{'arm64': '-'}>
+CONFIG_DRM_CHRONTEL_CH7033                      policy<{'arm64': '-'}>
+CONFIG_DRM_CIRRUS_QEMU                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_CROS_EC_ANX7688                      policy<{'arm64': '-'}>
+CONFIG_DRM_DEBUG_DP_MST_TOPOLOGY_REFS           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_DEBUG_SELFTEST                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_DISPLAY_CONNECTOR                    policy<{'arm64': '-'}>
+CONFIG_DRM_DP_AUX_BUS                           policy<{'arm64': '-'}>
+CONFIG_DRM_DP_AUX_CHARDEV                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_DP_CEC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_DW_HDMI                              policy<{'arm64': '-'}>
+CONFIG_DRM_DW_HDMI_AHB_AUDIO                    policy<{'arm64': '-'}>
+CONFIG_DRM_DW_HDMI_CEC                          policy<{'arm64': '-'}>
+CONFIG_DRM_DW_HDMI_I2S_AUDIO                    policy<{'arm64': '-'}>
+CONFIG_DRM_DW_MIPI_DSI                          policy<{'arm64': '-'}>
+CONFIG_DRM_ETNAVIV                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_ETNAVIV_THERMAL                      policy<{'arm64': '-'}>
+CONFIG_DRM_FBDEV_EMULATION                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_FBDEV_LEAK_PHYS_SMEM                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_FBDEV_OVERALLOC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_GEM_CMA_HELPER                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_GEM_SHMEM_HELPER                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_GM12U320                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_GMA500                               policy<{'amd64': '-'}>
+CONFIG_DRM_GUD                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_HDLCD                                policy<{'arm64': '-'}>
+CONFIG_DRM_HDLCD_SHOW_UNDERRUN                  policy<{'arm64': '-'}>
+CONFIG_DRM_HISI_KIRIN                           policy<{'arm64': '-'}>
+CONFIG_DRM_HYPERV                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_I2C_ADV7511                          policy<{'arm64': '-'}>
+CONFIG_DRM_I2C_ADV7511_AUDIO                    policy<{'arm64': '-'}>
+CONFIG_DRM_I2C_ADV7511_CEC                      policy<{'arm64': '-'}>
+CONFIG_DRM_I2C_CH7006                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_I2C_NXP_TDA9950                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_I2C_NXP_TDA998X                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_I2C_SIL164                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_I915                                 policy<{'amd64': '-'}>
+CONFIG_DRM_I915_CAPTURE_ERROR                   policy<{'amd64': '-'}>
+CONFIG_DRM_I915_COMPRESS_ERROR                  policy<{'amd64': '-'}>
+CONFIG_DRM_I915_DEBUG                           policy<{'amd64': '-'}>
+CONFIG_DRM_I915_DEBUG_GUC                       policy<{'amd64': '-'}>
+CONFIG_DRM_I915_DEBUG_MMIO                      policy<{'amd64': '-'}>
+CONFIG_DRM_I915_DEBUG_RUNTIME_PM                policy<{'amd64': '-'}>
+CONFIG_DRM_I915_DEBUG_VBLANK_EVADE              policy<{'amd64': '-'}>
+CONFIG_DRM_I915_FENCE_TIMEOUT                   policy<{'amd64': '-'}>
+CONFIG_DRM_I915_FORCE_PROBE                     policy<{'amd64': '-'}>
+CONFIG_DRM_I915_GVT                             policy<{'amd64': '-'}>
+CONFIG_DRM_I915_GVT_KVMGT                       policy<{'amd64': '-'}>
+CONFIG_DRM_I915_HEARTBEAT_INTERVAL              policy<{'amd64': '-'}>
+CONFIG_DRM_I915_LOW_LEVEL_TRACEPOINTS           policy<{'amd64': '-'}>
+CONFIG_DRM_I915_MAX_REQUEST_BUSYWAIT            policy<{'amd64': '-'}>
+CONFIG_DRM_I915_PREEMPT_TIMEOUT                 policy<{'amd64': '-'}>
+CONFIG_DRM_I915_REQUEST_TIMEOUT                 policy<{'amd64': '-'}>
+CONFIG_DRM_I915_SELFTEST                        policy<{'amd64': '-'}>
+CONFIG_DRM_I915_STOP_TIMEOUT                    policy<{'amd64': '-'}>
+CONFIG_DRM_I915_SW_FENCE_CHECK_DAG              policy<{'amd64': '-'}>
+CONFIG_DRM_I915_SW_FENCE_DEBUG_OBJECTS          policy<{'amd64': '-'}>
+CONFIG_DRM_I915_TIMESLICE_DURATION              policy<{'amd64': '-'}>
+CONFIG_DRM_I915_USERFAULT_AUTOSUSPEND           policy<{'amd64': '-'}>
+CONFIG_DRM_I915_USERPTR                         policy<{'amd64': '-'}>
+CONFIG_DRM_I915_WERROR                          policy<{'amd64': '-'}>
+CONFIG_DRM_IMX_DCSS                             policy<{'arm64': '-'}>
+CONFIG_DRM_ITE_IT66121                          policy<{'arm64': '-'}>
+CONFIG_DRM_KMB_DISPLAY                          policy<{'arm64': '-'}>
+CONFIG_DRM_KMS_CMA_HELPER                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_KMS_HELPER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_KOMEDA                               policy<{'arm64': '-'}>
+CONFIG_DRM_LIMA                                 policy<{'arm64': '-'}>
+CONFIG_DRM_LOAD_EDID_FIRMWARE                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_LONTIUM_LT8912B                      policy<{'arm64': '-'}>
+CONFIG_DRM_LONTIUM_LT9611                       policy<{'arm64': '-'}>
+CONFIG_DRM_LONTIUM_LT9611UXC                    policy<{'arm64': '-'}>
+CONFIG_DRM_LVDS_CODEC                           policy<{'arm64': '-'}>
+CONFIG_DRM_MALI_DISPLAY                         policy<{'arm64': '-'}>
+CONFIG_DRM_MEDIATEK                             policy<{'arm64': '-'}>
+CONFIG_DRM_MEDIATEK_HDMI                        policy<{'arm64': '-'}>
+CONFIG_DRM_MEGACHIPS_STDPXXXX_GE_B850V3_FW      policy<{'arm64': '-'}>
+CONFIG_DRM_MESON                                policy<{'arm64': '-'}>
+CONFIG_DRM_MESON_DW_HDMI                        policy<{'arm64': '-'}>
+CONFIG_DRM_MIPI_DBI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_MIPI_DSI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_MSM                                  policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_DP                               policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_DSI                              policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_DSI_10NM_PHY                     policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_DSI_14NM_PHY                     policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_DSI_20NM_PHY                     policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_DSI_28NM_8960_PHY                policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_DSI_28NM_PHY                     policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_DSI_7NM_PHY                      policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_GPU_STATE                        policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_GPU_SUDO                         policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_HDMI_HDCP                        policy<{'arm64': '-'}>
+CONFIG_DRM_MSM_REGISTER_LOGGING                 policy<{'arm64': '-'}>
+CONFIG_DRM_MXS                                  policy<{'arm64': '-'}>
+CONFIG_DRM_MXSFB                                policy<{'arm64': '-'}>
+CONFIG_DRM_NOUVEAU                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_NOUVEAU_BACKLIGHT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_NOUVEAU_SVM                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_NWL_MIPI_DSI                         policy<{'arm64': '-'}>
+CONFIG_DRM_NXP_PTN3460                          policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_PANEL_ABT_Y030XX067A                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_ARM_VERSATILE                  policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_ASUS_Z00T_TM5P5_NT35596        policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_BOE_HIMAX8279D                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_BOE_TV101WUM_NL6               policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_BRIDGE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_PANEL_DSI_CM                         policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_ELIDA_KD35T133                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_FEIXIN_K101_IM2BA02            policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_FEIYANG_FY07024DI26A30D        policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_ILITEK_IL9322                  policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_ILITEK_ILI9341                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_ILITEK_ILI9881C                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_INNOLUX_EJ030NA                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_INNOLUX_P079ZCA                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_JDI_LT070ME05000               policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_KHADAS_TS050                   policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_KINGDISPLAY_KD097D04           policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_LEADTEK_LTK050H3146W           policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_LEADTEK_LTK500HD1829           policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_LG_LB035Q02                    policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_LG_LG4573                      policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_LVDS                           policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_MANTIX_MLAF057WE51             policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_NEC_NL8048HL11                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_NOVATEK_NT35510                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_NOVATEK_NT36672A               policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_NOVATEK_NT39016                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_OLIMEX_LCD_OLINUXINO           policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_ORISETECH_OTM8009A             policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_OSD_OSD101T2587_53TS           policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_PANASONIC_VVX10F034N00         policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_RASPBERRYPI_TOUCHSCREEN        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_PANEL_RAYDIUM_RM67191                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_RAYDIUM_RM68200                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_RONBO_RB070D30                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_ATNA33XC20             policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_DB7430                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_LD9040                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_S6D16D0                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_S6E3HA2                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_S6E63J0X03             policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_S6E63M0                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_S6E63M0_DSI            policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_S6E63M0_SPI            policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_S6E88A0_AMS452EF01     policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_S6E8AA0                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SAMSUNG_SOFEF00                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SEIKO_43WVF1G                  policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SHARP_LQ101R1SX01              policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SHARP_LS037V7DW01              policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SHARP_LS043T1LE01              policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SIMPLE                         policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SITRONIX_ST7701                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SITRONIX_ST7703                policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SITRONIX_ST7789V               policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SONY_ACX424AKP                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_SONY_ACX565AKM                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_TDO_TL070WSH30                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_TPO_TD028TTEC1                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_TPO_TD043MTEA1                 policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_TPO_TPG110                     policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_TRULY_NT35597_WQXGA            policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_VISIONOX_RM69299               policy<{'arm64': '-'}>
+CONFIG_DRM_PANEL_WIDECHIPS_WS2401               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_PANEL_XINPENG_XPP055C272             policy<{'arm64': '-'}>
+CONFIG_DRM_PANFROST                             policy<{'arm64': '-'}>
+CONFIG_DRM_PARADE_PS8622                        policy<{'arm64': '-'}>
+CONFIG_DRM_PARADE_PS8640                        policy<{'arm64': '-'}>
+CONFIG_DRM_PL111                                policy<{'arm64': '-'}>
+CONFIG_DRM_QXL                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_RADEON                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_RADEON_USERPTR                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_RCAR_CMM                             policy<{'arm64': '-'}>
+CONFIG_DRM_RCAR_DU                              policy<{'arm64': '-'}>
+CONFIG_DRM_RCAR_DW_HDMI                         policy<{'arm64': '-'}>
+CONFIG_DRM_RCAR_LVDS                            policy<{'arm64': '-'}>
+CONFIG_DRM_RCAR_USE_CMM                         policy<{'arm64': '-'}>
+CONFIG_DRM_RCAR_USE_LVDS                        policy<{'arm64': '-'}>
+CONFIG_DRM_RCAR_VSP                             policy<{'arm64': '-'}>
+CONFIG_DRM_RCAR_WRITEBACK                       policy<{'arm64': '-'}>
+CONFIG_DRM_ROCKCHIP                             policy<{'arm64': '-'}>
+CONFIG_DRM_SCHED                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_SII902X                              policy<{'arm64': '-'}>
+CONFIG_DRM_SII9234                              policy<{'arm64': '-'}>
+CONFIG_DRM_SIL_SII8620                          policy<{'arm64': '-'}>
+CONFIG_DRM_SIMPLEDRM                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_SIMPLE_BRIDGE                        policy<{'arm64': '-'}>
+CONFIG_DRM_SUN4I                                policy<{'arm64': '-'}>
+CONFIG_DRM_SUN4I_BACKEND                        policy<{'arm64': '-'}>
+CONFIG_DRM_SUN4I_HDMI                           policy<{'arm64': '-'}>
+CONFIG_DRM_SUN4I_HDMI_CEC                       policy<{'arm64': '-'}>
+CONFIG_DRM_SUN6I_DSI                            policy<{'arm64': '-'}>
+CONFIG_DRM_SUN8I_DW_HDMI                        policy<{'arm64': '-'}>
+CONFIG_DRM_SUN8I_MIXER                          policy<{'arm64': '-'}>
+CONFIG_DRM_SUN8I_TCON_TOP                       policy<{'arm64': '-'}>
+CONFIG_DRM_TEGRA                                policy<{'arm64': '-'}>
+CONFIG_DRM_TEGRA_DEBUG                          policy<{'arm64': '-'}>
+CONFIG_DRM_TEGRA_STAGING                        policy<{'arm64': '-'}>
+CONFIG_DRM_THINE_THC63LVD1024                   policy<{'arm64': '-'}>
+CONFIG_DRM_TIDSS                                policy<{'arm64': '-'}>
+CONFIG_DRM_TI_SN65DSI83                         policy<{'arm64': '-'}>
+CONFIG_DRM_TI_SN65DSI86                         policy<{'arm64': '-'}>
+CONFIG_DRM_TI_TFP410                            policy<{'arm64': '-'}>
+CONFIG_DRM_TI_TPD12S015                         policy<{'arm64': '-'}>
+CONFIG_DRM_TOSHIBA_TC358762                     policy<{'arm64': '-'}>
+CONFIG_DRM_TOSHIBA_TC358764                     policy<{'arm64': '-'}>
+CONFIG_DRM_TOSHIBA_TC358767                     policy<{'arm64': '-'}>
+CONFIG_DRM_TOSHIBA_TC358768                     policy<{'arm64': '-'}>
+CONFIG_DRM_TOSHIBA_TC358775                     policy<{'arm64': '-'}>
+CONFIG_DRM_TTM                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_TTM_HELPER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_UDL                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_VC4                                  policy<{'arm64': '-'}>
+CONFIG_DRM_VC4_HDMI_CEC                         policy<{'arm64': '-'}>
+CONFIG_DRM_VGEM                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_VIRTIO_GPU                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_VKMS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_VMWGFX                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_VMWGFX_FBCON                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_VMWGFX_MKSSTATS                      policy<{'amd64': '-'}>
+CONFIG_DRM_VRAM_HELPER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_XEN                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_XEN_FRONTEND                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DRM_ZYNQMP_DPSUB                         policy<{'arm64': '-'}>
+CONFIG_DS1682                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DS1803                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DS4424                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DTPM                                     policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_DTPM_CPU                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DT_IDLE_STATES                           policy<{'arm64': '-'}>
+CONFIG_DUMMY_IRQ                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DVB_A8293                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AF9013                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AF9033                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AS102                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AS102_FE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ASCOT2E                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ATBM8830                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AU8522                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AU8522_DTV                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AU8522_V4L                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AV7110                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AV7110_IR                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_AV7110_OSD                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_B2C2_FLEXCOP                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_B2C2_FLEXCOP_PCI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_B2C2_FLEXCOP_PCI_DEBUG               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_B2C2_FLEXCOP_USB                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_B2C2_FLEXCOP_USB_DEBUG               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_BCM3510                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_BT8XX                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_BUDGET                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_BUDGET_AV                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_BUDGET_CI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_BUDGET_CORE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_BUDGET_PATCH                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CORE                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CX22700                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CX22702                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CX24110                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CX24116                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CX24117                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CX24120                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CX24123                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CXD2099                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CXD2820R                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CXD2841ER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_CXD2880                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DDBRIDGE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DDBRIDGE_MSIENABLE                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DEMUX_SECTION_LOSS_LOG               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DIB3000MB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DIB3000MC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DIB7000M                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DIB7000P                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DIB8000                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DIB9000                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DM1105                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DRX39XYJ                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DRXD                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DRXK                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DS3000                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_DYNAMIC_MINORS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_EC100                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_FIREDTV                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_FIREDTV_INPUT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_GP8PSK_FE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_HELENE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_HOPPER                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_HORUS3A                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ISL6405                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ISL6421                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ISL6423                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_IX2505V                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_L64781                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LG2160                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LGDT3305                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LGDT3306A                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LGDT330X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LGS8GL5                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LGS8GXX                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LNBH25                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LNBH29                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LNBP21                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_LNBP22                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_M88DS3103                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_M88RS2000                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MANTIS                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MAX_ADAPTERS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MB86A16                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MB86A20S                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MMAP                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MN88443X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MN88472                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MN88473                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MT312                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MT352                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MXL5XX                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_MXL692                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_NET                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_NETUP_UNIDVB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_NGENE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_NXT200X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_NXT6000                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_OR51132                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_OR51211                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_PLATFORM_DRIVERS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_PLL                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_PLUTO2                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_PT1                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_PT3                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_RTL2830                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_RTL2832                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_RTL2832_SDR                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_S5H1409                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_S5H1411                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_S5H1420                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_S5H1432                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_S921                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_SI2165                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_SI2168                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_SI21XX                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_SMIPCIE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_SP2                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_SP8870                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_SP887X                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STB0899                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STB6000                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STB6100                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV0288                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV0297                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV0299                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV0367                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV0900                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV090x                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV0910                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV6110                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV6110x                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_STV6111                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TC90522                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA10021                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA10023                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA10048                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA1004X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA10071                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA10086                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA18271C2DD                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA665x                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA8083                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA8261                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TDA826X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TEST_DRIVERS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TS2020                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TTUSB_BUDGET                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TTUSB_DEC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TUA6100                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TUNER_CX24113                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TUNER_DIB0070                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TUNER_DIB0090                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_TUNER_ITD1000                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ULE_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_A800                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_AF9005                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_AF9005_REMOTE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_AF9015                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_AF9035                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_ANYSEE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_AU6610                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_AZ6007                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_AZ6027                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_CE6230                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_CINERGY_T2                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_CXUSB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_CXUSB_ANALOG                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DIB0700                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DIB3000MC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DIBUSB_MB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DIBUSB_MB_FAULTY                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DIBUSB_MC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DIGITV                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DTT200U                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DTV5100                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DVBSKY                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_DW2102                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_EC168                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_GL861                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_GP8PSK                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_LME2510                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_M920X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_MXL111SF                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_NOVA_T_USB2                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_OPERA1                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_PCTV452E                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_RTL28XXU                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_TECHNISAT_USB2                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_TTUSB2                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_UMT_010                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_V2                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_VP702X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_VP7045                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_USB_ZD1301                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_VES1820                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_VES1X93                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ZD1301_DEMOD                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ZL10036                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ZL10039                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DVB_ZL10353                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DWC_XLGMAC                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DWC_XLGMAC_PCI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DWMAC_DWC_QOS_ETH                        policy<{'arm64': '-'}>
+CONFIG_DWMAC_GENERIC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DWMAC_IMX8                               policy<{'arm64': '-'}>
+CONFIG_DWMAC_INTEL                              policy<{'amd64': '-'}>
+CONFIG_DWMAC_INTEL_PLAT                         policy<{'arm64': '-'}>
+CONFIG_DWMAC_IPQ806X                            policy<{'arm64': '-'}>
+CONFIG_DWMAC_LOONGSON                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DWMAC_MEDIATEK                           policy<{'arm64': '-'}>
+CONFIG_DWMAC_MESON                              policy<{'arm64': '-'}>
+CONFIG_DWMAC_QCOM_ETHQOS                        policy<{'arm64': '-'}>
+CONFIG_DWMAC_ROCKCHIP                           policy<{'arm64': '-'}>
+CONFIG_DWMAC_SOCFPGA                            policy<{'arm64': '-'}>
+CONFIG_DWMAC_SUN8I                              policy<{'arm64': '-'}>
+CONFIG_DWMAC_SUNXI                              policy<{'arm64': '-'}>
+CONFIG_DWMAC_VISCONTI                           policy<{'arm64': '-'}>
+CONFIG_DW_APB_ICTL                              policy<{'arm64': '-'}>
+CONFIG_DW_APB_TIMER                             policy<{'arm64': '-'}>
+CONFIG_DW_APB_TIMER_OF                          policy<{'arm64': '-'}>
+CONFIG_DW_AXI_DMAC                              policy<{'arm64': 'n'}>
+CONFIG_DW_DMAC                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DW_DMAC_CORE                             policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_DW_DMAC_PCI                              policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_DW_EDMA                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DW_EDMA_PCIE                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DW_I3C_MASTER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_DW_WATCHDOG                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DW_XDATA_PCIE                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_DYNAMIC_FTRACE                           policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_DYNAMIC_FTRACE_WITH_REGS                 policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_DYNAMIC_PHYSICAL_MASK                    policy<{'amd64': '-'}>
+CONFIG_EARLY_PRINTK_DBGP                        policy<{'amd64': 'n'}>
+CONFIG_EARLY_PRINTK_USB                         policy<{'amd64': '-'}>
+CONFIG_EARLY_PRINTK_USB_XDBC                    policy<{'amd64': 'n'}>
+CONFIG_EBC_C384_WDT                             policy<{'amd64': 'n'}>
+CONFIG_ECHO                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ECRYPT_FS_MESSAGING                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EDAC                                     policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_EDAC_ALTERA                              policy<{'arm64': '-'}>
+CONFIG_EDAC_ALTERA_ETHERNET                     policy<{'arm64': '-'}>
+CONFIG_EDAC_ALTERA_NAND                         policy<{'arm64': '-'}>
+CONFIG_EDAC_ALTERA_OCRAM                        policy<{'arm64': '-'}>
+CONFIG_EDAC_ALTERA_QSPI                         policy<{'arm64': '-'}>
+CONFIG_EDAC_ALTERA_SDMMC                        policy<{'arm64': '-'}>
+CONFIG_EDAC_ALTERA_SDRAM                        policy<{'arm64': '-'}>
+CONFIG_EDAC_ALTERA_USB                          policy<{'arm64': '-'}>
+CONFIG_EDAC_BLUEFIELD                           policy<{'arm64': '-'}>
+CONFIG_EDAC_DMC520                              policy<{'arm64': 'n'}>
+CONFIG_EDAC_GHES                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EDAC_I10NM                               policy<{'amd64': 'n'}>
+CONFIG_EDAC_IE31200                             policy<{'amd64': 'n'}>
+CONFIG_EDAC_IGEN6                               policy<{'amd64': 'n'}>
+CONFIG_EDAC_LAYERSCAPE                          policy<{'arm64': '-'}>
+CONFIG_EDAC_PND2                                policy<{'amd64': 'n'}>
+CONFIG_EDAC_QCOM                                policy<{'arm64': '-'}>
+CONFIG_EDAC_SKX                                 policy<{'amd64': 'n'}>
+CONFIG_EDAC_SYNOPSYS                            policy<{'arm64': '-'}>
+CONFIG_EDAC_THUNDERX                            policy<{'arm64': 'n'}>
+CONFIG_EDAC_XGENE                               policy<{'arm64': 'n'}>
+CONFIG_EDD                                      policy<{'amd64': 'n'}>
+CONFIG_EDD_OFF                                  policy<{'amd64': '-'}>
+CONFIG_EEEPC_LAPTOP                             policy<{'amd64': '-'}>
+CONFIG_EEEPC_WMI                                policy<{'amd64': '-'}>
+CONFIG_EEPROM_93CX6                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EEPROM_93XX46                            policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EEPROM_AT24                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EEPROM_AT25                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EEPROM_EE1004                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EEPROM_IDT_89HPESX                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EEPROM_LEGACY                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EEPROM_MAX6875                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EFI_ARMSTUB_DTB_LOADER                   policy<{'arm64': 'y'}>
+CONFIG_EFI_BOOTLOADER_CONTROL                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EFI_CAPSULE_LOADER                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EFI_DEV_PATH_PARSER                      policy<{'amd64': '-'}>
+CONFIG_EFI_EMBEDDED_FIRMWARE                    policy<{'amd64': '-'}>
+CONFIG_EFI_MIXED                                policy<{'amd64': 'n'}>
+CONFIG_EFI_RCI2_TABLE                           policy<{'amd64': 'n'}>
+CONFIG_EFI_SOFT_RESERVE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EFI_TEST                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EFI_VARS_PSTORE                          policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_EFI_VARS_PSTORE_DEFAULT_DISABLE          policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_EFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EINT_MTK                                 policy<{'arm64': '-'}>
+CONFIG_EISA                                     policy<{'amd64': 'n'}>
+CONFIG_EISA_NAMES                               policy<{'amd64': '-'}>
+CONFIG_EISA_PCI_EISA                            policy<{'amd64': '-'}>
+CONFIG_EISA_VIRTUAL_ROOT                        policy<{'amd64': '-'}>
+CONFIG_EISA_VLB_PRIMING                         policy<{'amd64': '-'}>
+CONFIG_EL3                                      policy<{'amd64': '-'}>
+CONFIG_EMAC_ROCKCHIP                            policy<{'arm64': '-'}>
+CONFIG_ENABLE_DEFAULT_TRACERS                   policy<{'arm64': '-'}>
+CONFIG_ENC28J60                                 policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_ENC28J60_WRITEVERIFY                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ENCX24J600                               policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_ENERGY_MODEL                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ENIC                                     policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_ENVELOPE_DETECTOR                        policy<{'arm64': '-'}>
+CONFIG_EPIC100                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EQUALIZER                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EROFS_FS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EROFS_FS_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EROFS_FS_POSIX_ACL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EROFS_FS_SECURITY                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EROFS_FS_XATTR                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EROFS_FS_ZIP                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ET131X                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ETHOC                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EUROTECH_WDT                             policy<{'amd64': 'n'}>
+CONFIG_EVM_ADD_XATTRS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EVM_EXTRA_SMACK_XATTRS                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXFAT_DEFAULT_IOCHARSET                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXFAT_FS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EXPORTFS_BLOCK_OPS                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_EXTCON                                   policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_EXTCON_ADC_JACK                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXTCON_AXP288                            policy<{'amd64': '-'}>
+CONFIG_EXTCON_FSA9480                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EXTCON_GPIO                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EXTCON_INTEL_CHT_WC                      policy<{'amd64': '-'}>
+CONFIG_EXTCON_INTEL_INT3496                     policy<{'amd64': '-'}>
+CONFIG_EXTCON_INTEL_MRFLD                       policy<{'amd64': '-'}>
+CONFIG_EXTCON_MAX14577                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXTCON_MAX3355                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EXTCON_MAX77693                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXTCON_MAX77843                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXTCON_MAX8997                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXTCON_PALMAS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXTCON_PTN5150                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EXTCON_QCOM_SPMI_MISC                    policy<{'arm64': '-'}>
+CONFIG_EXTCON_RT8973A                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EXTCON_SM5502                            policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EXTCON_USBC_CROS_EC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXTCON_USBC_TUSB320                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_EXTCON_USB_GPIO                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_EZCHIP_NPS_MANAGEMENT_ENET               policy<{'arm64': 'n'}>
+CONFIG_EZX_PCAP                                 policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_F2FS_CHECK_FS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FAULT_INJECTION                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_F2FS_FS_COMPRESSION                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS_LZ4                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS_LZ4HC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS_LZO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS_LZORLE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS_POSIX_ACL                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS_SECURITY                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS_XATTR                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_FS_ZSTD                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_IOSTAT                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F2FS_STAT_FS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_F71808E_WDT                              policy<{'amd64': 'n'}>
+CONFIG_FARSYNC                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_3DFX                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_3DFX_ACCEL                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_3DFX_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_ARC                                   policy<{'amd64': 'n'}>
+CONFIG_FB_ARK                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_ARMCLCD                               policy<{'arm64': 'y'}>
+CONFIG_FB_ASILIANT                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_ATY                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_ATY128                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_ATY128_BACKLIGHT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_ATY_BACKLIGHT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_ATY_CT                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_ATY_GENERIC_LCD                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_ATY_GX                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_BACKLIGHT                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_CARILLO_RANCH                         policy<{'amd64': '-'}>
+CONFIG_FB_CARMINE                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_CARMINE_DRAM_EVAL                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_CIRRUS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_CYBER2000                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_CYBER2000_DDC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_DDC                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_HECUBA                                policy<{'amd64': '-'}>
+CONFIG_FB_HGA                                   policy<{'amd64': 'n'}>
+CONFIG_FB_I740                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_IMSTT                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_IMX                                   policy<{'arm64': '-'}>
+CONFIG_FB_INTEL                                 policy<{'amd64': '-'}>
+CONFIG_FB_INTEL_DEBUG                           policy<{'amd64': '-'}>
+CONFIG_FB_INTEL_I2C                             policy<{'amd64': '-'}>
+CONFIG_FB_KYRO                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_LE80578                               policy<{'amd64': 'n'}>
+CONFIG_FB_MATROX                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_MATROX_G                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_MATROX_I2C                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_MATROX_MAVEN                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_MATROX_MILLENIUM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_MATROX_MYSTIQUE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_MB862XX                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_MB862XX_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_MB862XX_PCI_GDC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_METRONOME                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_MODE_HELPERS                          policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_FB_MX3                                   policy<{'arm64': '-'}>
+CONFIG_FB_N411                                  policy<{'amd64': 'n'}>
+CONFIG_FB_NEOMAGIC                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_NVIDIA                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_NVIDIA_BACKLIGHT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_NVIDIA_DEBUG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_NVIDIA_I2C                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_OPENCORES                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_PM2                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_PM2_FIFO_DISCONNECT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_PM3                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_RADEON                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_RADEON_BACKLIGHT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_RADEON_DEBUG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_RADEON_I2C                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_RIVA                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_RIVA_BACKLIGHT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_RIVA_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_RIVA_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_S1D13XXX                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_S3                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_S3_DDC                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_SAVAGE                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_SAVAGE_ACCEL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_SAVAGE_I2C                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_SH_MOBILE_LCDC                        policy<{'arm64': '-'}>
+CONFIG_FB_SIMPLE                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_SIS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_SIS_300                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_SIS_315                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_SM501                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_SM712                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_SM750                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_SMSCUFX                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_SSD1307                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_SVGALIB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_AGM1264K_FL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_BD663474                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_HX8340BN                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_HX8347D                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_HX8353D                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_HX8357D                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ILI9163                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ILI9320                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ILI9325                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ILI9340                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ILI9341                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ILI9481                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ILI9486                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_PCD8544                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_RA8875                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_S6D02A1                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_S6D1121                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_SEPS525                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_SH1106                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_SSD1289                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_SSD1305                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_SSD1306                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_SSD1331                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_SSD1351                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ST7735R                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_ST7789V                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_TINYLCD                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_TLS8204                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_UC1611                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_UC1701                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_UPD161704                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TFT_WATTEROTT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FB_TILEBLITTING                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_TRIDENT                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_UDL                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_UVESA                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_VGA16                                 policy<{'amd64': 'n'}>
+CONFIG_FB_VIA                                   policy<{'amd64': 'n'}>
+CONFIG_FB_VIA_DIRECT_PROCFS                     policy<{'amd64': '-'}>
+CONFIG_FB_VIA_X_COMPATIBILITY                   policy<{'amd64': '-'}>
+CONFIG_FB_VOODOO1                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_VT8623                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FB_XILINX                                policy<{'arm64': '-'}>
+CONFIG_FDDI                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FEALNX                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FEC                                      policy<{'arm64': '-'}>
+CONFIG_FIELDBUS_DEV                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FIREWIRE                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FIREWIRE_NET                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FIREWIRE_NOSY                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FIREWIRE_OHCI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FIREWIRE_SBP2                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FIREWIRE_SERIAL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FIRMWARE_EDID                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FIRMWARE_MEMMAP                          policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_FIXED_PHY                                policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_FM10K                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FONTS                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FONT_10x18                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_6x10                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_6x11                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_6x8                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_7x14                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_ACORN_8x8                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_MINI_4x6                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_PEARL_8x8                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_SUN12x22                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_SUN8x16                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FONT_TER16x32                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FPGA_BRIDGE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL_AFU                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL_EMIF                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL_FME                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL_FME_BRIDGE                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL_FME_MGR                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL_FME_REGION                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL_NIOS_INTEL_PAC_N3000            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_DFL_PCI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_MGR_ALTERA_CVP                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_MGR_ALTERA_PS_SPI                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_MGR_ICE40_SPI                       policy<{'arm64': '-'}>
+CONFIG_FPGA_MGR_MACHXO2_SPI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_MGR_SOCFPGA                         policy<{'arm64': '-'}>
+CONFIG_FPGA_MGR_SOCFPGA_A10                     policy<{'arm64': '-'}>
+CONFIG_FPGA_MGR_STRATIX10_SOC                   policy<{'arm64': '-'}>
+CONFIG_FPGA_MGR_VERSAL_FPGA                     policy<{'arm64': '-'}>
+CONFIG_FPGA_MGR_XILINX_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FPGA_MGR_ZYNQMP_FPGA                     policy<{'arm64': '-'}>
+CONFIG_FPGA_REGION                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FRAME_POINTER                            policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_FRAME_WARN                               policy<{'amd64': '2048', 'arm64': '2048'}>
+CONFIG_FSI                                      policy<{'arm64': 'n'}>
+CONFIG_FSI_MASTER_ASPEED                        policy<{'arm64': '-'}>
+CONFIG_FSI_MASTER_GPIO                          policy<{'arm64': '-'}>
+CONFIG_FSI_MASTER_HUB                           policy<{'arm64': '-'}>
+CONFIG_FSI_NEW_DEV_NODE                         policy<{'arm64': '-'}>
+CONFIG_FSI_OCC                                  policy<{'arm64': '-'}>
+CONFIG_FSI_SBEFIFO                              policy<{'arm64': '-'}>
+CONFIG_FSI_SCOM                                 policy<{'arm64': '-'}>
+CONFIG_FSL_BMAN_TEST                            policy<{'arm64': '-'}>
+CONFIG_FSL_BMAN_TEST_API                        policy<{'arm64': '-'}>
+CONFIG_FSL_DPAA                                 policy<{'arm64': '-'}>
+CONFIG_FSL_DPAA2_ETH                            policy<{'arm64': '-'}>
+CONFIG_FSL_DPAA2_ETH_DCB                        policy<{'arm64': '-'}>
+CONFIG_FSL_DPAA2_PTP_CLOCK                      policy<{'arm64': '-'}>
+CONFIG_FSL_DPAA2_QDMA                           policy<{'arm64': '-'}>
+CONFIG_FSL_DPAA2_SWITCH                         policy<{'arm64': '-'}>
+CONFIG_FSL_DPAA_CHECKING                        policy<{'arm64': '-'}>
+CONFIG_FSL_DPAA_ETH                             policy<{'arm64': '-'}>
+CONFIG_FSL_EDMA                                 policy<{'arm64': 'n'}>
+CONFIG_FSL_ENETC                                policy<{'arm64': '-'}>
+CONFIG_FSL_ENETC_IERB                           policy<{'arm64': '-'}>
+CONFIG_FSL_ENETC_MDIO                           policy<{'arm64': '-'}>
+CONFIG_FSL_ENETC_PTP_CLOCK                      policy<{'arm64': '-'}>
+CONFIG_FSL_ENETC_QOS                            policy<{'arm64': '-'}>
+CONFIG_FSL_ENETC_VF                             policy<{'arm64': '-'}>
+CONFIG_FSL_FMAN                                 policy<{'arm64': '-'}>
+CONFIG_FSL_GUTS                                 policy<{'arm64': '-'}>
+CONFIG_FSL_IFC                                  policy<{'arm64': '-'}>
+CONFIG_FSL_IMX8_DDR_PMU                         policy<{'arm64': '-'}>
+CONFIG_FSL_MC_BUS                               policy<{'arm64': '-'}>
+CONFIG_FSL_MC_DPIO                              policy<{'arm64': '-'}>
+CONFIG_FSL_MC_UAPI_SUPPORT                      policy<{'arm64': '-'}>
+CONFIG_FSL_PQ_MDIO                              policy<{'arm64': '-'}>
+CONFIG_FSL_QDMA                                 policy<{'arm64': 'n'}>
+CONFIG_FSL_QMAN_TEST                            policy<{'arm64': '-'}>
+CONFIG_FSL_RCPM                                 policy<{'arm64': 'n'}>
+CONFIG_FSL_UCC_HDLC                             policy<{'arm64': '-'}>
+CONFIG_FSL_XGMAC_MDIO                           policy<{'arm64': '-'}>
+CONFIG_FS_DAX                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FS_DAX_PMD                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FS_ENCRYPTION_INLINE_CRYPT               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FS_VERITY                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FS_VERITY_BUILTIN_SIGNATURES             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FS_VERITY_DEBUG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FTL                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FTM_QUADDEC                              policy<{'arm64': '-'}>
+CONFIG_FTRACE_MCOUNT_RECORD                     policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_FTRACE_MCOUNT_USE_PATCHABLE_FUNCTION_ENTRY policy<{'arm64': '-'}>
+CONFIG_FTRACE_RECORD_RECURSION                  policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_FTRACE_SYSCALLS                          policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_FUEL_GAUGE_SC27XX                        policy<{'arm64': '-'}>
+CONFIG_FUJITSU_ES                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FUJITSU_LAPTOP                           policy<{'amd64': '-'}>
+CONFIG_FUJITSU_TABLET                           policy<{'amd64': 'n'}>
+CONFIG_FUNCTION_ERROR_INJECTION                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FUNCTION_GRAPH_TRACER                    policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_FUNCTION_PROFILER                        policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_FUNCTION_TRACER                          policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_FUSE_DAX                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FUSION_FC                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FUSION_LAN                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FUSION_MAX_SGE                           policy<{'amd64': '40', 'arm64': '40'}>
+CONFIG_FWNODE_MDIO                              policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_FWTTY_MAX_CARD_PORTS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FWTTY_MAX_TOTAL_PORTS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FW_ATTR_CLASS                            policy<{'amd64': '-'}>
+CONFIG_FW_LOADER_COMPRESS                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_FW_LOADER_COMPRESS_XZ                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FW_LOADER_PAGED_BUF                      policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_FW_LOADER_USER_HELPER                    policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_FXAS21002C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FXAS21002C_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FXAS21002C_SPI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FXLS8962AF                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FXLS8962AF_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FXLS8962AF_SPI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FXOS8700                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FXOS8700_I2C                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_FXOS8700_SPI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GADGET_UAC1                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GADGET_UAC1_LEGACY                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GAMEPORT                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GAMEPORT_EMU10K1                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GAMEPORT_FM801                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GAMEPORT_L4                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GAMEPORT_NS558                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GCC_PLUGINS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GCC_PLUGIN_CYC_COMPLEXITY                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GCC_PLUGIN_LATENT_ENTROPY                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GCC_PLUGIN_RANDSTRUCT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GCC_PLUGIN_STACKLEAK                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF_ALL          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GCC_PLUGIN_STRUCTLEAK_USER               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GDB_SCRIPTS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GEMINI_ETHERNET                          policy<{'arm64': 'n'}>
+CONFIG_GENERIC_ADC_BATTERY                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GENERIC_ADC_THERMAL                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GENERIC_IRQ_CHIP                         policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_GENERIC_PINCONF                          policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_GENERIC_PINCTRL_GROUPS                   policy<{'arm64': '-'}>
+CONFIG_GENERIC_PINMUX_FUNCTIONS                 policy<{'arm64': '-'}>
+CONFIG_GENWQE                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GENWQE_PLATFORM_ERROR_RECOVERY           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GFS2_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GFS2_FS_LOCKING_DLM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GIANFAR                                  policy<{'arm64': '-'}>
+CONFIG_GIGABYTE_WMI                             policy<{'amd64': '-'}>
+CONFIG_GNSS                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GNSS_MTK_SERIAL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GNSS_SERIAL                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GNSS_SIRF_SERIAL                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GNSS_UBX_SERIAL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GP2AP002                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GP2AP020A00F                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPD_POCKET_FAN                           policy<{'amd64': 'n'}>
+CONFIG_GPIOLIB_IRQCHIP                          policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_GPIO_104_DIO_48E                         policy<{'amd64': '-'}>
+CONFIG_GPIO_104_IDIO_16                         policy<{'amd64': '-'}>
+CONFIG_GPIO_104_IDI_48                          policy<{'amd64': '-'}>
+CONFIG_GPIO_74X164                              policy<{'arm64': 'n'}>
+CONFIG_GPIO_74XX_MMIO                           policy<{'arm64': 'n'}>
 CONFIG_GPIO_AAEON                               policy<{'amd64': '-'}>
+CONFIG_GPIO_ADNP                                policy<{'arm64': 'n'}>
+CONFIG_GPIO_ADP5520                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_ADP5588                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_AGGREGATOR                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_ALTERA                              policy<{'arm64': 'n'}>
+CONFIG_GPIO_ALTERA_A10SR                        policy<{'arm64': '-'}>
+CONFIG_GPIO_AMD8111                             policy<{'amd64': 'n'}>
+CONFIG_GPIO_AMDPT                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_AMD_FCH                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_ARIZONA                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_BCM_XGS_IPROC                       policy<{'arm64': 'y'}>
+CONFIG_GPIO_BD70528                             policy<{'arm64': '-'}>
+CONFIG_GPIO_BD71815                             policy<{'arm64': '-'}>
+CONFIG_GPIO_BD71828                             policy<{'arm64': '-'}>
+CONFIG_GPIO_BD9571MWV                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_BRCMSTB                             policy<{'arm64': '-'}>
+CONFIG_GPIO_BT8XX                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_CADENCE                             policy<{'arm64': 'n'}>
+CONFIG_GPIO_CRYSTAL_COVE                        policy<{'amd64': '-'}>
+CONFIG_GPIO_DA9052                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_DA9055                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_DAVINCI                             policy<{'arm64': '-'}>
+CONFIG_GPIO_DLN2                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_DWAPB                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_EIC_SPRD                            policy<{'arm64': 'n'}>
+CONFIG_GPIO_EXAR                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_F7188X                              policy<{'amd64': 'n'}>
+CONFIG_GPIO_FTGPIO010                           policy<{'arm64': 'n'}>
+CONFIG_GPIO_GENERIC                             policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_GPIO_GENERIC_PLATFORM                    policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_GPIO_GPIO_MM                             policy<{'amd64': '-'}>
+CONFIG_GPIO_GRGPIO                              policy<{'arm64': 'n'}>
+CONFIG_GPIO_GW_PLD                              policy<{'arm64': 'n'}>
+CONFIG_GPIO_HISI                                policy<{'arm64': 'n'}>
+CONFIG_GPIO_HLWD                                policy<{'arm64': 'n'}>
+CONFIG_GPIO_ICH                                 policy<{'amd64': '-'}>
+CONFIG_GPIO_IT87                                policy<{'amd64': 'n'}>
+CONFIG_GPIO_JANZ_TTL                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_KEMPLD                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_LJCA                                policy<{'amd64': '-'}>
+CONFIG_GPIO_LOGICVC                             policy<{'arm64': 'n'}>
+CONFIG_GPIO_LP3943                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_LP873X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_LP87565                             policy<{'arm64': '-'}>
 CONFIG_GPIO_M058SSAN                            policy<{'amd64': '-'}>
+CONFIG_GPIO_MADERA                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_MAX3191X                            policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_GPIO_MAX7300                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_MAX7301                             policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_GPIO_MAX730X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_MAX732X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_MAX77620                            policy<{'arm64': '-'}>
+CONFIG_GPIO_MAX77650                            policy<{'arm64': '-'}>
+CONFIG_GPIO_MB86S7X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_MC33880                             policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_GPIO_MENZ127                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_MLXBF                               policy<{'arm64': '-'}>
+CONFIG_GPIO_MLXBF2                              policy<{'arm64': '-'}>
+CONFIG_GPIO_ML_IOH                              policy<{'amd64': 'n'}>
+CONFIG_GPIO_MOXTET                              policy<{'arm64': '-'}>
+CONFIG_GPIO_MPC8XXX                             policy<{'arm64': '-'}>
+CONFIG_GPIO_MVEBU                               policy<{'arm64': '-'}>
+CONFIG_GPIO_MXC                                 policy<{'arm64': '-'}>
+CONFIG_GPIO_PALMAS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_PCA953X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_PCA953X_IRQ                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_PCA9570                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_PCF857X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_PCIE_IDIO_24                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_PCI_IDIO_16                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_PISOSR                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_GPIO_PMIC_EIC_SPRD                       policy<{'arm64': '-'}>
+CONFIG_GPIO_RASPBERRYPI_EXP                     policy<{'arm64': '-'}>
+CONFIG_GPIO_RC5T583                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_RCAR                                policy<{'arm64': '-'}>
+CONFIG_GPIO_RDC321X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_REGMAP                              policy<{'arm64': '-'}>
+CONFIG_GPIO_ROCKCHIP                            policy<{'arm64': 'y'}>
+CONFIG_GPIO_SAMA5D2_PIOBU                       policy<{'arm64': 'n'}>
+CONFIG_GPIO_SCH                                 policy<{'amd64': '-'}>
+CONFIG_GPIO_SCH311X                             policy<{'amd64': 'n'}>
+CONFIG_GPIO_SIFIVE                              policy<{'arm64': 'n'}>
+CONFIG_GPIO_SIOX                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_SL28CPLD                            policy<{'arm64': '-'}>
+CONFIG_GPIO_SPRD                                policy<{'arm64': 'n'}>
+CONFIG_GPIO_STMPE                               policy<{'arm64': '-'}>
+CONFIG_GPIO_SYSCON                              policy<{'arm64': 'n'}>
+CONFIG_GPIO_TC3589X                             policy<{'arm64': '-'}>
+CONFIG_GPIO_TEGRA186                            policy<{'arm64': '-'}>
+CONFIG_GPIO_THUNDERX                            policy<{'arm64': 'n'}>
+CONFIG_GPIO_TPIC2810                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_TPS65086                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_TPS65218                            policy<{'arm64': '-'}>
+CONFIG_GPIO_TPS6586X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_TPS65910                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_TPS65912                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_TPS68470                            policy<{'amd64': '-'}>
+CONFIG_GPIO_TQMX86                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_TWL6040                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_UCB1400                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_VIPERBOARD                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_VIRTIO                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GPIO_VISCONTI                            policy<{'arm64': '-'}>
+CONFIG_GPIO_VX855                               policy<{'amd64': 'n'}>
+CONFIG_GPIO_WATCHDOG                            policy<{'arm64': 'n'}>
+CONFIG_GPIO_WCD934X                             policy<{'arm64': '-'}>
+CONFIG_GPIO_WHISKEY_COVE                        policy<{'amd64': '-'}>
+CONFIG_GPIO_WINBOND                             policy<{'amd64': 'n'}>
+CONFIG_GPIO_WM831X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_WM8350                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_WM8994                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GPIO_WS16C48                             policy<{'amd64': 'n'}>
+CONFIG_GPIO_XGENE_SB                            policy<{'arm64': 'y'}>
+CONFIG_GPIO_XILINX                              policy<{'arm64': 'n'}>
+CONFIG_GPIO_XLP                                 policy<{'arm64': '-'}>
+CONFIG_GPIO_XRA1403                             policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_GPIO_ZYNQ                                policy<{'arm64': '-'}>
+CONFIG_GREENASIA_FF                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GREYBUS_AUDIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_AUDIO_APB_CODEC                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_BOOTROM                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_BRIDGED_PHY                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_ES2                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_FIRMWARE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_GPIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_HID                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_LIGHT                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_LOG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_LOOPBACK                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_POWER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_PWM                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_RAW                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_SDIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_UART                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_USB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GREYBUS_VIBRATOR                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GS_FPGABOOT                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_GTP                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_GVE                                      policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_HABANA_AI                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HALTPOLL_CPUIDLE                         policy<{'amd64': 'y'}>
+CONFIG_HAMACHI                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HAMRADIO                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HAPPYMEAL                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HARDENED_USERCOPY_FALLBACK               policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_HAVE_ARCH_USERFAULTFD_MINOR              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HAVE_ARCH_USERFAULTFD_WP                 policy<{'amd64': '-'}>
+CONFIG_HAVE_IMA_KEXEC                           policy<{'arm64': '-'}>
+CONFIG_HAVE_SCHED_AVG_IRQ                       policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_HBMC_AM654                               policy<{'arm64': '-'}>
+CONFIG_HD44780                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HD44780_COMMON                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDC100X                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDC2010                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDLC                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDLC_CISCO                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDLC_FR                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDLC_PPP                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDLC_RAW                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDLC_RAW_ETH                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDLC_X25                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDMI                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HDMI_LPE_AUDIO                           policy<{'amd64': '-'}>
+CONFIG_HERMES                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HERMES_CACHE_FW_ON_INIT                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HERMES_PRISM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HFI1_DEBUG_SDMA_ORDER                    policy<{'amd64': '-'}>
+CONFIG_HFSPLUS_FS                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HI13X1_GMAC                              policy<{'arm64': '-'}>
+CONFIG_HI3660_MBOX                              policy<{'arm64': '-'}>
+CONFIG_HI6220_MBOX                              policy<{'arm64': '-'}>
+CONFIG_HI6421V600_IRQ                           policy<{'arm64': '-'}>
+CONFIG_HI8435                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HIBERNATION_SNAPSHOT_DEV                 policy<{'amd64': '-'}>
+CONFIG_HID                                      policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_HID_ACCUTOUCH                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ACRUX                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ACRUX_FF                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_ALPS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_APPLEIR                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ASUS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_AUREAL                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_BATTERY_STRENGTH                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_BETOP_FF                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_BIGBEN_FF                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_CHICONY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_CMEDIA                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_CORSAIR                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_COUGAR                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_CP2112                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_CREATIVE_SB0540                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_CYPRESS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_DRAGONRISE                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ELAN                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ELECOM                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ELO                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_EMS_FF                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_FT260                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_GEMBIRD                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_GENERIC                              policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_HID_GFRM                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_GLORIOUS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_GOOGLE_HAMMER                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_GREENASIA                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_GT683R                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_GYRATION                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_HOLTEK                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ICADE                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ITE                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_JABRA                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_KENSINGTON                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_KEYTOUCH                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_KYE                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_LCPOWER                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_LED                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_LENOVO                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_LOGITECH_DJ                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_LOGITECH_HIDPP                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_MACALLY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_MAGICMOUSE                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_MALTRON                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_MAYFLASH                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_MCP2221                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_MULTITOUCH                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_NTI                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_NTRIG                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ORTEK                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PANTHERLORD                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PENMOUNT                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PETALYNX                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PICOLCD                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PICOLCD_BACKLIGHT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_PICOLCD_CIR                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_PICOLCD_FB                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_PICOLCD_LCD                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_PICOLCD_LEDS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_PID                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PLANTRONICS                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PLAYSTATION                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PRIMAX                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_PRODIKEYS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_REDRAGON                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_RETRODE                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_RMI                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ROCCAT                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_SAITEK                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_SAMSUNG                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_SEMITEK                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_SENSOR_ACCEL_3D                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_ALS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_CUSTOM_INTEL_HINGE            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_CUSTOM_SENSOR                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_DEVICE_ROTATION               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_GYRO_3D                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_HUB                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_SENSOR_HUMIDITY                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_IIO_COMMON                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_IIO_TRIGGER                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_INCLINOMETER_3D               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_MAGNETOMETER_3D               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_PRESS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_PROX                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SENSOR_TEMP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HID_SMARTJOYPLUS                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_SONY                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_SPEEDLINK                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_STEAM                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_STEELSERIES                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_SUNPLUS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_THINGM                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_THRUSTMASTER                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_TIVO                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_TOPSEED                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_TWINHAN                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_U2FZERO                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_UCLOGIC                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_UDRAW_PS3                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_VIEWSONIC                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_VIVALDI                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_WACOM                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_WALTOP                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_WIIMOTE                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_XINMO                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ZEROPLUS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HID_ZYDACRON                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HINIC                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HIP04_ETH                                policy<{'arm64': 'n'}>
+CONFIG_HISILICON_IRQ_MBIGEN                     policy<{'arm64': '-'}>
+CONFIG_HISILICON_LPC                            policy<{'arm64': '-'}>
+CONFIG_HISI_DMA                                 policy<{'arm64': '-'}>
+CONFIG_HISI_FEMAC                               policy<{'arm64': 'n'}>
+CONFIG_HISI_HIKEY_USB                           policy<{'arm64': '-'}>
+CONFIG_HISI_PMU                                 policy<{'arm64': 'n'}>
+CONFIG_HISI_THERMAL                             policy<{'arm64': '-'}>
+CONFIG_HIST_TRIGGERS                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HIST_TRIGGERS_DEBUG                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HIX5HD2_GMAC                             policy<{'arm64': 'n'}>
+CONFIG_HMC425                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HMC6352                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HMEM_REPORTING                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HMM_MIRROR                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HMS_ANYBUSS_BUS                          policy<{'arm64': '-'}>
+CONFIG_HMS_PROFINET                             policy<{'arm64': '-'}>
+CONFIG_HNS                                      policy<{'arm64': '-'}>
+CONFIG_HNS3                                     policy<{'arm64': 'n'}>
+CONFIG_HNS3_DCB                                 policy<{'arm64': '-'}>
+CONFIG_HNS3_ENET                                policy<{'arm64': '-'}>
+CONFIG_HNS3_HCLGE                               policy<{'arm64': '-'}>
+CONFIG_HNS3_HCLGEVF                             policy<{'arm64': '-'}>
+CONFIG_HNS_DSAF                                 policy<{'arm64': 'n'}>
+CONFIG_HNS_ENET                                 policy<{'arm64': 'n'}>
+CONFIG_HNS_MDIO                                 policy<{'arm64': '-'}>
+CONFIG_HOLTEK_FF                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HOSTAP                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HOSTAP_CS                                policy<{'amd64': '-'}>
+CONFIG_HOSTAP_FIRMWARE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HOSTAP_FIRMWARE_NVRAM                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HOSTAP_PCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HOSTAP_PLX                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HOTPLUG_PCI_ACPI_IBM                     policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_HOTPLUG_PCI_CPCI                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HOTPLUG_PCI_CPCI_GENERIC                 policy<{'amd64': '-'}>
+CONFIG_HOTPLUG_PCI_CPCI_ZT5550                  policy<{'amd64': '-'}>
+CONFIG_HP03                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HP206C                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HPFS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HPWDT_NMI_DECODING                       policy<{'amd64': '-'}>
+CONFIG_HP_ACCEL                                 policy<{'amd64': '-'}>
+CONFIG_HP_WATCHDOG                              policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_HP_WMI                                   policy<{'amd64': '-'}>
+CONFIG_HSA_AMD                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HSA_AMD_SVM                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HSI                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HSI_BOARDINFO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HSI_CHAR                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HSR                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HT16K33                                  policy<{'arm64': '-'}>
+CONFIG_HTC_I2CPLD                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HTC_PASIC3                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HTS221                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HTS221_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HTS221_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HTU21                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HUAWEI_WMI                               policy<{'amd64': '-'}>
+CONFIG_HWLAT_TRACER                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HWMON                                    policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_HWMON_VID                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HWPOISON_INJECT                          policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_HWSPINLOCK                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HWSPINLOCK_OMAP                          policy<{'arm64': '-'}>
+CONFIG_HWSPINLOCK_QCOM                          policy<{'arm64': '-'}>
+CONFIG_HWSPINLOCK_SPRD                          policy<{'arm64': '-'}>
+CONFIG_HWSPINLOCK_SUN6I                         policy<{'arm64': '-'}>
+CONFIG_HW_RANDOM_AMD                            policy<{'amd64': 'y'}>
+CONFIG_HW_RANDOM_ARM_SMCCC_TRNG                 policy<{'arm64': 'y'}>
+CONFIG_HW_RANDOM_BA431                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HW_RANDOM_BCM2835                        policy<{'arm64': 'y'}>
+CONFIG_HW_RANDOM_CAVIUM                         policy<{'arm64': 'y'}>
+CONFIG_HW_RANDOM_CCTRNG                         policy<{'arm64': 'n'}>
+CONFIG_HW_RANDOM_HISI                           policy<{'arm64': '-'}>
+CONFIG_HW_RANDOM_INTEL                          policy<{'amd64': 'y'}>
+CONFIG_HW_RANDOM_IPROC_RNG200                   policy<{'arm64': 'y'}>
+CONFIG_HW_RANDOM_MESON                          policy<{'arm64': '-'}>
+CONFIG_HW_RANDOM_MTK                            policy<{'arm64': '-'}>
+CONFIG_HW_RANDOM_OMAP                           policy<{'arm64': '-'}>
+CONFIG_HW_RANDOM_OPTEE                          policy<{'arm64': '-'}>
+CONFIG_HW_RANDOM_VIA                            policy<{'amd64': 'y'}>
+CONFIG_HW_RANDOM_VIRTIO                         policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_HW_RANDOM_XGENE                          policy<{'arm64': 'y'}>
+CONFIG_HW_RANDOM_XIPHERA                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HX711                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_HYPERV_VSOCKETS                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_HZ                                       policy<{'amd64': '1000', 'arm64': '1000'}>
+CONFIG_HZ_1000                                  policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_HZ_250                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C                                      policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_I2C_ALGOPCA                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_ALI1535                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_ALI1563                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_ALI15X3                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_ALTERA                               policy<{'arm64': '-'}>
+CONFIG_I2C_AMD756_S4882                         policy<{'amd64': 'n'}>
+CONFIG_I2C_AMD_MP2                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_ARB_GPIO_CHALLENGE                   policy<{'arm64': '-'}>
+CONFIG_I2C_BCM2835                              policy<{'arm64': 'n'}>
+CONFIG_I2C_CBUS_GPIO                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_CHT_WC                               policy<{'amd64': '-'}>
+CONFIG_I2C_COMPAT                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_CP2615                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_CROS_EC_TUNNEL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_DEMUX_PINCTRL                        policy<{'arm64': '-'}>
+CONFIG_I2C_DESIGNWARE_BAYTRAIL                  policy<{'amd64': '-'}>
+CONFIG_I2C_DESIGNWARE_CORE                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_DESIGNWARE_PCI                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_DESIGNWARE_PLATFORM                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_DESIGNWARE_SLAVE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_DIOLAN_U2C                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_DLN2                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_FSI                                  policy<{'arm64': '-'}>
+CONFIG_I2C_GPIO                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_GPIO_FAULT_INJECTOR                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_HID_ACPI                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_HID_CORE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_HID_OF                               policy<{'arm64': 'n'}>
+CONFIG_I2C_HID_OF_GOODIX                        policy<{'arm64': 'n'}>
+CONFIG_I2C_HISI                                 policy<{'arm64': 'n'}>
+CONFIG_I2C_HIX5HD2                              policy<{'arm64': '-'}>
+CONFIG_I2C_IMX                                  policy<{'arm64': '-'}>
+CONFIG_I2C_IMX_LPI2C                            policy<{'arm64': '-'}>
+CONFIG_I2C_ISCH                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_ISMT                                 policy<{'amd64': 'n'}>
+CONFIG_I2C_KEMPLD                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_LJCA                                 policy<{'amd64': '-'}>
+CONFIG_I2C_MESON                                policy<{'arm64': '-'}>
+CONFIG_I2C_MLXBF                                policy<{'arm64': '-'}>
+CONFIG_I2C_MLXCPLD                              policy<{'amd64': 'n'}>
+CONFIG_I2C_MT65XX                               policy<{'arm64': '-'}>
+CONFIG_I2C_MULTI_INSTANTIATE                    policy<{'amd64': '-'}>
+CONFIG_I2C_MUX                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_MUX_GPIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_MUX_GPMUX                            policy<{'arm64': '-'}>
+CONFIG_I2C_MUX_LTC4306                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_MUX_MLXCPLD                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_MUX_PCA9541                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_MUX_PCA954x                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_MUX_PINCTRL                          policy<{'arm64': '-'}>
+CONFIG_I2C_MUX_REG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_MV64XXX                              policy<{'arm64': '-'}>
+CONFIG_I2C_NFORCE2                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_NFORCE2_S4985                        policy<{'amd64': '-'}>
+CONFIG_I2C_NOMADIK                              policy<{'arm64': 'n'}>
+CONFIG_I2C_NVIDIA_GPU                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_OCORES                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_OMAP                                 policy<{'arm64': '-'}>
+CONFIG_I2C_OWL                                  policy<{'arm64': '-'}>
+CONFIG_I2C_PARPORT                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_PCA_PLATFORM                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_PXA                                  policy<{'arm64': '-'}>
+CONFIG_I2C_PXA_SLAVE                            policy<{'arm64': '-'}>
+CONFIG_I2C_QCOM_CCI                             policy<{'arm64': '-'}>
+CONFIG_I2C_QCOM_GENI                            policy<{'arm64': '-'}>
+CONFIG_I2C_QUP                                  policy<{'arm64': '-'}>
+CONFIG_I2C_RCAR                                 policy<{'arm64': '-'}>
+CONFIG_I2C_RIIC                                 policy<{'arm64': '-'}>
+CONFIG_I2C_RK3X                                 policy<{'arm64': 'n'}>
+CONFIG_I2C_ROBOTFUZZ_OSIF                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_SCMI                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_SH_MOBILE                            policy<{'arm64': '-'}>
+CONFIG_I2C_SI470X                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_SI4713                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_SIMTEC                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_SIS5595                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_SIS630                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_SIS96X                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_SLAVE_EEPROM                         policy<{'arm64': 'n'}>
+CONFIG_I2C_SPRD                                 policy<{'arm64': '-'}>
+CONFIG_I2C_STUB                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_SYNQUACER                            policy<{'arm64': '-'}>
+CONFIG_I2C_TAOS_EVM                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_TEGRA                                policy<{'arm64': 'n'}>
+CONFIG_I2C_TEGRA_BPMP                           policy<{'arm64': '-'}>
+CONFIG_I2C_THUNDERX                             policy<{'arm64': 'n'}>
+CONFIG_I2C_TINY_USB                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_VERSATILE                            policy<{'arm64': 'n'}>
+CONFIG_I2C_VIA                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_VIAPRO                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_VIPERBOARD                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_I2C_VIRTIO                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_XGENE_SLIMPRO                        policy<{'arm64': 'n'}>
+CONFIG_I2C_XILINX                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I2C_XLP9XX                               policy<{'arm64': '-'}>
+CONFIG_I3C                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I40E_DCB                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I6300ESB_WDT                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_I82092                                   policy<{'amd64': '-'}>
+CONFIG_I8K                                      policy<{'amd64': 'n'}>
+CONFIG_IAQCORE                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IB700_WDT                                policy<{'amd64': 'n'}>
+CONFIG_IBMASR                                   policy<{'amd64': 'n'}>
+CONFIG_IBM_ASM                                  policy<{'amd64': 'n'}>
+CONFIG_IBM_RTL                                  policy<{'amd64': 'n'}>
+CONFIG_ICP10100                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ICPLUS_PHY                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ICS932S401                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ICST                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IDEAPAD_LAPTOP                           policy<{'amd64': '-'}>
+CONFIG_IDLE_INJECT                              policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_IE6XX_WDT                                policy<{'amd64': 'n'}>
+CONFIG_IEEE802154                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IEEE802154_6LOWPAN                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_ADF7242                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_AT86RF230                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_AT86RF230_DEBUGFS             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_ATUSB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_CA8210                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_CA8210_DEBUGFS                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_CC2520                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_DRIVERS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_FAKELB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_HWSIM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_MCR20A                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_MRF24J40                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_NL802154_EXPERIMENTAL         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IEEE802154_SOCKET                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IFCVF                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IGC                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IIO                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IIO_ADIS_LIB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ADIS_LIB_BUFFER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_BUFFER                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_BUFFER_CB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_BUFFER_DMA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_BUFFER_DMAENGINE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_BUFFER_HW_CONSUMER                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_CONFIGFS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_CONSUMERS_PER_TRIGGER                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_CROS_EC_ACCEL_LEGACY                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_CROS_EC_BARO                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_CROS_EC_LIGHT_PROX                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_CROS_EC_SENSORS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_CROS_EC_SENSORS_CORE                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_CROS_EC_SENSORS_LID_ANGLE            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_HRTIMER_TRIGGER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_INTERRUPT_TRIGGER                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_KFIFO_BUF                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_MS_SENSORS_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_MUX                                  policy<{'arm64': '-'}>
+CONFIG_IIO_RESCALE                              policy<{'arm64': '-'}>
+CONFIG_IIO_SCMI                                 policy<{'arm64': '-'}>
+CONFIG_IIO_SIMPLE_DUMMY                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_SSP_SENSORHUB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_SSP_SENSORS_COMMONS                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_ACCEL_3AXIS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_ACCEL_I2C_3AXIS                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_ACCEL_SPI_3AXIS                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_GYRO_3AXIS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_GYRO_I2C_3AXIS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_GYRO_SPI_3AXIS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_LSM6DSX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_LSM6DSX_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_LSM6DSX_I3C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_LSM6DSX_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_LSM9DS0                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_LSM9DS0_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_LSM9DS0_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_MAGN_3AXIS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_MAGN_I2C_3AXIS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_MAGN_SPI_3AXIS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_PRESS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_PRESS_I2C                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_PRESS_SPI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_SENSORS_CORE                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_SENSORS_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_ST_SENSORS_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_SW_DEVICE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_SW_TRIGGER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_SYSFS_TRIGGER                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_TIGHTLOOP_TRIGGER                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_TRIGGER                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_TRIGGERED_BUFFER                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IIO_TRIGGERED_EVENT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IKCONFIG                                 policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IKCONFIG_PROC                            policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IMA_APPRAISE_BUILD_POLICY                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IMA_APPRAISE_MODSIG                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IMA_BLACKLIST_KEYRING                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IMA_LOAD_X509                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IMG_ASCII_LCD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IMX2_WDT                                 policy<{'arm64': '-'}>
+CONFIG_IMX7D_ADC                                policy<{'arm64': '-'}>
+CONFIG_IMX7ULP_WDT                              policy<{'arm64': '-'}>
+CONFIG_IMX8MM_THERMAL                           policy<{'arm64': '-'}>
+CONFIG_IMX_DMA                                  policy<{'arm64': '-'}>
+CONFIG_IMX_DSP                                  policy<{'arm64': '-'}>
+CONFIG_IMX_GPCV2                                policy<{'arm64': '-'}>
+CONFIG_IMX_GPCV2_PM_DOMAINS                     policy<{'arm64': '-'}>
+CONFIG_IMX_INTMUX                               policy<{'arm64': '-'}>
+CONFIG_IMX_IRQSTEER                             policy<{'arm64': '-'}>
+CONFIG_IMX_MBOX                                 policy<{'arm64': '-'}>
+CONFIG_IMX_REMOTEPROC                           policy<{'arm64': '-'}>
+CONFIG_IMX_SCU                                  policy<{'arm64': '-'}>
+CONFIG_IMX_SCU_PD                               policy<{'arm64': '-'}>
+CONFIG_IMX_SC_THERMAL                           policy<{'arm64': '-'}>
+CONFIG_IMX_SC_WDT                               policy<{'arm64': '-'}>
+CONFIG_IMX_SDMA                                 policy<{'arm64': '-'}>
+CONFIG_IMX_THERMAL                              policy<{'arm64': '-'}>
+CONFIG_IMX_WEIM                                 policy<{'arm64': '-'}>
+CONFIG_INA2XX_ADC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INDIRECT_PIO                             policy<{'arm64': 'n'}>
+CONFIG_INET6_ESPINTCP                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INET6_ESP_OFFLOAD                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INET_DIAG_DESTROY                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INET_ESPINTCP                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INET_ESP_OFFLOAD                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INET_MPTCP_DIAG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INET_RAW_DIAG                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INFINIBAND                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INFINIBAND_ADDR_TRANS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_ADDR_TRANS_CONFIGFS           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_BNXT_RE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_CXGB4                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_EFA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_HFI1                          policy<{'amd64': '-'}>
+CONFIG_INFINIBAND_HNS                           policy<{'arm64': '-'}>
+CONFIG_INFINIBAND_HNS_HIP06                     policy<{'arm64': '-'}>
+CONFIG_INFINIBAND_HNS_HIP08                     policy<{'arm64': '-'}>
+CONFIG_INFINIBAND_IPOIB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_IPOIB_CM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_IPOIB_DEBUG                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_IPOIB_DEBUG_DATA              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_IRDMA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_ISER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_ISERT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_MTHCA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_MTHCA_DEBUG                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_OCRDMA                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_ON_DEMAND_PAGING              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_OPA_VNIC                      policy<{'amd64': '-'}>
+CONFIG_INFINIBAND_QEDR                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_QIB                           policy<{'amd64': '-'}>
+CONFIG_INFINIBAND_QIB_DCA                       policy<{'amd64': '-'}>
+CONFIG_INFINIBAND_RDMAVT                        policy<{'amd64': '-'}>
+CONFIG_INFINIBAND_RTRS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_RTRS_CLIENT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_RTRS_SERVER                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_SRP                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_SRPT                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_USER_ACCESS                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_USER_MAD                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_USER_MEM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_USNIC                         policy<{'amd64': '-'}>
+CONFIG_INFINIBAND_VIRT_DMA                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFINIBAND_VMWARE_PVRDMA                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INFTL                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INIT_ON_ALLOC_DEFAULT_ON                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INIT_STACK_ALL_PATTERN                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INIT_STACK_ALL_ZERO                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INLINE_READ_LOCK                         policy<{'arm64': '-'}>
+CONFIG_INLINE_READ_LOCK_BH                      policy<{'arm64': '-'}>
+CONFIG_INLINE_READ_LOCK_IRQ                     policy<{'arm64': '-'}>
+CONFIG_INLINE_READ_LOCK_IRQSAVE                 policy<{'arm64': '-'}>
+CONFIG_INLINE_READ_UNLOCK                       policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_INLINE_READ_UNLOCK_BH                    policy<{'arm64': '-'}>
+CONFIG_INLINE_READ_UNLOCK_IRQ                   policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_INLINE_READ_UNLOCK_IRQRESTORE            policy<{'arm64': '-'}>
+CONFIG_INLINE_SPIN_LOCK                         policy<{'arm64': '-'}>
+CONFIG_INLINE_SPIN_LOCK_BH                      policy<{'arm64': '-'}>
+CONFIG_INLINE_SPIN_LOCK_IRQ                     policy<{'arm64': '-'}>
+CONFIG_INLINE_SPIN_LOCK_IRQSAVE                 policy<{'arm64': '-'}>
+CONFIG_INLINE_SPIN_TRYLOCK                      policy<{'arm64': '-'}>
+CONFIG_INLINE_SPIN_TRYLOCK_BH                   policy<{'arm64': '-'}>
+CONFIG_INLINE_SPIN_UNLOCK_BH                    policy<{'arm64': '-'}>
+CONFIG_INLINE_SPIN_UNLOCK_IRQ                   policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_INLINE_SPIN_UNLOCK_IRQRESTORE            policy<{'arm64': '-'}>
+CONFIG_INLINE_WRITE_LOCK                        policy<{'arm64': '-'}>
+CONFIG_INLINE_WRITE_LOCK_BH                     policy<{'arm64': '-'}>
+CONFIG_INLINE_WRITE_LOCK_IRQ                    policy<{'arm64': '-'}>
+CONFIG_INLINE_WRITE_LOCK_IRQSAVE                policy<{'arm64': '-'}>
+CONFIG_INLINE_WRITE_UNLOCK                      policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_INLINE_WRITE_UNLOCK_BH                   policy<{'arm64': '-'}>
+CONFIG_INLINE_WRITE_UNLOCK_IRQ                  policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_INLINE_WRITE_UNLOCK_IRQRESTORE           policy<{'arm64': '-'}>
+CONFIG_INPUT_88PM80X_ONKEY                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_88PM860X_ONKEY                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_AD714X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_AD714X_I2C                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_AD714X_SPI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_ADXL34X                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_ADXL34X_I2C                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_ADXL34X_SPI                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_APANEL                             policy<{'amd64': 'n'}>
+CONFIG_INPUT_ARIZONA_HAPTICS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_ATC260X_ONKEY                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_ATI_REMOTE2                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_ATLAS_BTNS                         policy<{'amd64': 'n'}>
+CONFIG_INPUT_ATMEL_CAPTOUCH                     policy<{'arm64': 'n'}>
+CONFIG_INPUT_AXP20X_PEK                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_BMA150                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_CM109                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_CMA3000                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_CMA3000_I2C                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_CPCAP_PWRBUTTON                    policy<{'arm64': '-'}>
+CONFIG_INPUT_DA7280_HAPTICS                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_DA9052_ONKEY                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_DA9055_ONKEY                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_DA9063_ONKEY                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_DRV260X_HAPTICS                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_DRV2665_HAPTICS                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_DRV2667_HAPTICS                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_E3X0_BUTTON                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_EVBUG                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_EVDEV                              policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_INPUT_GPIO_BEEPER                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_GPIO_DECODER                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_GPIO_ROTARY_ENCODER                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_GPIO_VIBRA                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_HISI_POWERKEY                      policy<{'arm64': '-'}>
+CONFIG_INPUT_IDEAPAD_SLIDEBAR                   policy<{'amd64': 'n'}>
+CONFIG_INPUT_IMS_PCU                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_IQS269A                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_IQS626A                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_JOYDEV                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_JOYSTICK                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_KEYSPAN_REMOTE                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_KXTJ9                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_LEDS                               policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_INPUT_MATRIXKMAP                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_MAX77650_ONKEY                     policy<{'arm64': '-'}>
+CONFIG_INPUT_MAX77693_HAPTIC                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_MAX8925_ONKEY                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_MAX8997_HAPTIC                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_MC13783_PWRBUTTON                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_MMA8450                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_MOUSEDEV                           policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_INPUT_MOUSEDEV_PSAUX                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_PALMAS_PWRBUTTON                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_PCAP                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_PCF50633_PMU                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_PCF8574                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_PCSPKR                             policy<{'amd64': 'n'}>
+CONFIG_INPUT_PM8941_PWRKEY                      policy<{'arm64': '-'}>
+CONFIG_INPUT_PM8XXX_VIBRATOR                    policy<{'arm64': '-'}>
+CONFIG_INPUT_POWERMATE                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_PWM_BEEPER                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_PWM_VIBRA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_RAVE_SP_PWRBUTTON                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_REGULATOR_HAPTIC                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_RETU_PWRBUTTON                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_RK805_PWRKEY                       policy<{'arm64': '-'}>
+CONFIG_INPUT_SC27XX_VIBRA                       policy<{'arm64': '-'}>
+CONFIG_INPUT_SOC_BUTTON_ARRAY                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_SPARSEKMAP                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_STPMIC1_ONKEY                      policy<{'arm64': '-'}>
+CONFIG_INPUT_TABLET                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_TOUCHSCREEN                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INPUT_TPS65218_PWRBUTTON                 policy<{'arm64': '-'}>
+CONFIG_INPUT_TWL4030_PWRBUTTON                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_TWL4030_VIBRA                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_TWL6040_VIBRA                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_WM831X_ON                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INPUT_XEN_KBDDEV_FRONTEND                policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_INPUT_YEALINK                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INT3406_THERMAL                          policy<{'amd64': '-'}>
+CONFIG_INTEGRITY_ASYMMETRIC_KEYS                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEGRITY_SIGNATURE                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INTEGRITY_TRUSTED_KEYRING                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_ATOMISP                            policy<{'amd64': '-'}>
+CONFIG_INTEL_ATOMISP2_LED                       policy<{'amd64': '-'}>
+CONFIG_INTEL_ATOMISP2_PDX86                     policy<{'amd64': '-'}>
+CONFIG_INTEL_ATOMISP2_PM                        policy<{'amd64': 'n'}>
+CONFIG_INTEL_BXTWC_PMIC_TMU                     policy<{'amd64': '-'}>
+CONFIG_INTEL_BXT_PMIC_THERMAL                   policy<{'amd64': '-'}>
+CONFIG_INTEL_CHTDC_TI_PWRBTN                    policy<{'amd64': '-'}>
+CONFIG_INTEL_CHT_INT33FE                        policy<{'amd64': '-'}>
+CONFIG_INTEL_GTT                                policy<{'amd64': '-'}>
+CONFIG_INTEL_HID_EVENT                          policy<{'amd64': 'n'}>
+CONFIG_INTEL_IDMA64                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INTEL_IDXD                               policy<{'amd64': 'n'}>
+CONFIG_INTEL_IDXD_BUS                           policy<{'amd64': '-'}>
+CONFIG_INTEL_IDXD_PERFMON                       policy<{'amd64': '-'}>
+CONFIG_INTEL_IDXD_SVM                           policy<{'amd64': '-'}>
+CONFIG_INTEL_INT0002_VGPIO                      policy<{'amd64': 'n'}>
+CONFIG_INTEL_IOATDMA                            policy<{'amd64': 'y'}>
+CONFIG_INTEL_IOMMU_SCALABLE_MODE_DEFAULT_ON     policy<{'amd64': 'y'}>
+CONFIG_INTEL_IOMMU_SVM                          policy<{'amd64': 'n'}>
+CONFIG_INTEL_IPS                                policy<{'amd64': 'n'}>
+CONFIG_INTEL_ISH_FIRMWARE_DOWNLOADER            policy<{'amd64': '-'}>
+CONFIG_INTEL_ISH_HID                            policy<{'amd64': 'n'}>
+CONFIG_INTEL_LDMA                               policy<{'amd64': 'n'}>
+CONFIG_INTEL_MEI_HDCP                           policy<{'amd64': '-'}>
+CONFIG_INTEL_MEI_VSC                            policy<{'amd64': '-'}>
+CONFIG_INTEL_MEI_WDT                            policy<{'amd64': 'n'}>
+CONFIG_INTEL_MENLOW                             policy<{'amd64': 'n'}>
+CONFIG_INTEL_MRFLD_ADC                          policy<{'amd64': '-'}>
+CONFIG_INTEL_MRFLD_PWRBTN                       policy<{'amd64': '-'}>
+CONFIG_INTEL_OAKTRAIL                           policy<{'amd64': '-'}>
+CONFIG_INTEL_PCH_THERMAL                        policy<{'amd64': 'n'}>
+CONFIG_INTEL_PMC_CORE                           policy<{'amd64': 'n'}>
+CONFIG_INTEL_PMT_CLASS                          policy<{'amd64': '-'}>
+CONFIG_INTEL_PMT_CRASHLOG                       policy<{'amd64': '-'}>
+CONFIG_INTEL_PMT_TELEMETRY                      policy<{'amd64': '-'}>
+CONFIG_INTEL_POWERCLAMP                         policy<{'amd64': 'n'}>
+CONFIG_INTEL_PUNIT_IPC                          policy<{'amd64': 'n'}>
+CONFIG_INTEL_QEP                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_RST                                policy<{'amd64': 'n'}>
+CONFIG_INTEL_SAR_INT1092                        policy<{'amd64': 'n'}>
+CONFIG_INTEL_SCU                                policy<{'amd64': '-'}>
+CONFIG_INTEL_SCU_IPC                            policy<{'amd64': '-'}>
+CONFIG_INTEL_SCU_IPC_UTIL                       policy<{'amd64': '-'}>
+CONFIG_INTEL_SCU_PCI                            policy<{'amd64': 'n'}>
+CONFIG_INTEL_SCU_PLATFORM                       policy<{'amd64': 'n'}>
+CONFIG_INTEL_SKL_INT3472                        policy<{'amd64': 'n'}>
+CONFIG_INTEL_SMARTCONNECT                       policy<{'amd64': 'n'}>
+CONFIG_INTEL_SOC_DTS_THERMAL                    policy<{'amd64': 'n'}>
+CONFIG_INTEL_SOC_PMIC                           policy<{'amd64': '-'}>
+CONFIG_INTEL_SOC_PMIC_BXTWC                     policy<{'amd64': '-'}>
+CONFIG_INTEL_SOC_PMIC_CHTDC_TI                  policy<{'amd64': 'n'}>
+CONFIG_INTEL_SOC_PMIC_CHTWC                     policy<{'amd64': '-'}>
+CONFIG_INTEL_SOC_PMIC_MRFLD                     policy<{'amd64': '-'}>
+CONFIG_INTEL_SPEED_SELECT_INTERFACE             policy<{'amd64': 'n'}>
+CONFIG_INTEL_STRATIX10_RSU                      policy<{'arm64': '-'}>
+CONFIG_INTEL_STRATIX10_SERVICE                  policy<{'arm64': '-'}>
+CONFIG_INTEL_TCC_COOLING                        policy<{'amd64': 'n'}>
+CONFIG_INTEL_TELEMETRY                          policy<{'amd64': '-'}>
+CONFIG_INTEL_TH                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INTEL_TH_ACPI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_TH_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_TH_GTH                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_TH_MSU                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_TH_PCI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_TH_PTI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_TH_STH                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INTEL_TURBO_MAX_3                        policy<{'amd64': 'n'}>
+CONFIG_INTEL_TXT                                policy<{'amd64': 'n'}>
+CONFIG_INTEL_UNCORE_FREQ_CONTROL                policy<{'amd64': 'n'}>
+CONFIG_INTEL_VBTN                               policy<{'amd64': 'n'}>
+CONFIG_INTEL_VSC                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INTEL_VSC_ACE                            policy<{'amd64': '-'}>
+CONFIG_INTEL_VSC_ACE_DEBUG                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INTEL_VSC_CSI                            policy<{'amd64': '-'}>
+CONFIG_INTEL_VSC_PSE                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INTEL_WMI                                policy<{'amd64': '-'}>
+CONFIG_INTEL_WMI_SBL_FW_UPDATE                  policy<{'amd64': '-'}>
+CONFIG_INTEL_WMI_THUNDERBOLT                    policy<{'amd64': '-'}>
+CONFIG_INTEL_XWAY_PHY                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INTERCONNECT                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_INTERCONNECT_IMX                         policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_IMX8MM                      policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_IMX8MN                      policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_IMX8MQ                      policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM                        policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_BCM_VOTER              policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_MSM8916                policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_MSM8939                policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_MSM8974                policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_OSM_L3                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_QCS404                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_RPMH                   policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_RPMH_POSSIBLE          policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SC7180                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SC7280                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SC8180X                policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SDM660                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SDM845                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SDX55                  policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SM8150                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SM8250                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SM8350                 policy<{'arm64': '-'}>
+CONFIG_INTERCONNECT_QCOM_SMD_RPM                policy<{'arm64': '-'}>
+CONFIG_INTERRUPT_CNT                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INV_ICM42600                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INV_ICM42600_I2C                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INV_ICM42600_SPI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INV_MPU6050_I2C                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INV_MPU6050_IIO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_INV_MPU6050_SPI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IOASID                                   policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_IOMMU_SVA_LIB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IONIC                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IOSCHED_BFQ                              policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IOSF_MBI_DEBUG                           policy<{'amd64': 'n'}>
+CONFIG_IOSM                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IO_DELAY_0X80                            policy<{'amd64': 'y'}>
+CONFIG_IO_DELAY_0XED                            policy<{'amd64': 'n'}>
+CONFIG_IO_STRICT_DEVMEM                         policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IPACK_BUS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IPMB_DEVICE_INTERFACE                    policy<{'arm64': 'n'}>
+CONFIG_IPMI_PANIC_EVENT                         policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IPMI_PANIC_STRING                        policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IPQ_APSS_6018                            policy<{'arm64': '-'}>
+CONFIG_IPQ_APSS_PLL                             policy<{'arm64': '-'}>
+CONFIG_IPQ_GCC_4019                             policy<{'arm64': '-'}>
+CONFIG_IPQ_GCC_6018                             policy<{'arm64': '-'}>
+CONFIG_IPQ_GCC_806X                             policy<{'arm64': '-'}>
+CONFIG_IPQ_GCC_8074                             policy<{'arm64': '-'}>
+CONFIG_IPQ_LCC_806X                             policy<{'arm64': '-'}>
+CONFIG_IPV6_ILA                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IPV6_IOAM6_LWTUNNEL                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IPV6_OPTIMISTIC_DAD                      policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IPV6_SEG6_BPF                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPV6_SEG6_HMAC                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IPV6_SEG6_LWTUNNEL                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IPVTAP                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IPW2100                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPW2100_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPW2100_MONITOR                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPW2200                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPW2200_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPW2200_MONITOR                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPW2200_PROMISCUOUS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPW2200_QOS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPW2200_RADIOTAP                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IPWIRELESS                               policy<{'amd64': '-'}>
+CONFIG_IP_DCCP_CCID3                            policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IP_DCCP_CCID3_DEBUG                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IP_DCCP_TFRC_LIB                         policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IP_NF_IPTABLES                           policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IP_SET_HASH_IPMAC                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IP_VS_MH                                 policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_IP_VS_OVF                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IP_VS_TWOS                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IQS620AT_TEMP                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IQS621_ALS                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IQS624_POS                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IRQ_FASTEOI_HIERARCHY_HANDLERS           policy<{'arm64': '-'}>
+CONFIG_IRQ_TIME_ACCOUNTING                      policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_IR_ENE                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_FINTEK                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_GPIO_CIR                              policy<{'arm64': '-'}>
+CONFIG_IR_GPIO_TX                               policy<{'arm64': '-'}>
+CONFIG_IR_HIX5HD2                               policy<{'arm64': '-'}>
+CONFIG_IR_IGORPLUGUSB                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_IGUANA                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_IMON                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_IMON_DECODER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_IMON_RAW                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_ITE_CIR                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_JVC_DECODER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_MCEUSB                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_MCE_KBD_DECODER                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_MESON                                 policy<{'arm64': '-'}>
+CONFIG_IR_MESON_TX                              policy<{'arm64': '-'}>
+CONFIG_IR_MTK                                   policy<{'arm64': '-'}>
+CONFIG_IR_NEC_DECODER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_NUVOTON                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_PWM_TX                                policy<{'arm64': '-'}>
+CONFIG_IR_RC5_DECODER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_RC6_DECODER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_RCMM_DECODER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_REDRAT3                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_SANYO_DECODER                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_SERIAL                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_SERIAL_TRANSMITTER                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_SHARP_DECODER                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_SIR                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_SONY_DECODER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_SPI                                   policy<{'arm64': '-'}>
+CONFIG_IR_STREAMZAP                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_SUNXI                                 policy<{'arm64': '-'}>
+CONFIG_IR_TOY                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_TTUSBIR                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IR_WINBOND_CIR                           policy<{'amd64': '-'}>
+CONFIG_IR_XMP_DECODER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ISA_BUS                                  policy<{'amd64': 'n'}>
+CONFIG_ISA_BUS_API                              policy<{'amd64': '-'}>
+CONFIG_ISCSI_IBFT                               policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_ISCSI_TARGET_CXGB4                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ISDN                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ISDN_CAPI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ISDN_CAPI_MIDDLEWARE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ISL29003                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ISL29020                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ISL29125                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ISL29501                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IT8712F_WDT                              policy<{'amd64': 'n'}>
+CONFIG_IT87_WDT                                 policy<{'amd64': 'n'}>
+CONFIG_ITG3200                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWL3945                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWL4965                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLDVM                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLEGACY                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLEGACY_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLEGACY_DEBUGFS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLMVM                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLWIFI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLWIFI_BCAST_FILTERING                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLWIFI_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLWIFI_DEBUGFS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLWIFI_DEVICE_TRACING                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLWIFI_LEDS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IWLWIFI_OPMODE_MODULAR                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IXGBEVF_IPSEC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_IXGBE_DCB                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_IXGBE_IPSEC                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JAILHOUSE_GUEST                          policy<{'amd64': 'n'}>
+CONFIG_JFFS2_CMODE_FAVOURLZO                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_CMODE_NONE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_CMODE_PRIORITY                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_CMODE_SIZE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_COMPRESSION_OPTIONS                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_FS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_JFFS2_FS_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_FS_POSIX_ACL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_FS_SECURITY                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_FS_WBUF_VERIFY                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_FS_WRITEBUFFER                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_FS_XATTR                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_LZO                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_RTIME                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_RUBIN                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_SUMMARY                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFFS2_ZLIB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFS_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_JFS_POSIX_ACL                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFS_SECURITY                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JFS_STATISTICS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_A3D                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_ADC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_ADI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_ANALOG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_AS5011                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_COBRA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_DB9                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_FSIA6B                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_GAMECON                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_GF2K                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_GRIP                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_GRIP_MP                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_GUILLEMOT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_IFORCE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_IFORCE_232                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_IFORCE_USB                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_INTERACT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_JOYDUMP                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_MAGELLAN                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_PSXPAD_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_PSXPAD_SPI_FF                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_PXRC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_QWIIC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_SIDEWINDER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_SPACEBALL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_SPACEORB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_STINGER                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_TMDC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_TURBOGRAFX                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_TWIDJOY                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_WALKERA0701                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_WARRIOR                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_XPAD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_XPAD_FF                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_XPAD_LEDS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JOYSTICK_ZHENHUA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_JSA1212                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_K3_DMA                                   policy<{'arm64': '-'}>
+CONFIG_K3_RTI_WATCHDOG                          policy<{'arm64': '-'}>
+CONFIG_K3_THERMAL                               policy<{'arm64': '-'}>
+CONFIG_KARMA_PARTITION                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KDB_CONTINUE_CATASTROPHIC                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KDB_DEFAULT_ENABLE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KDB_KEYBOARD                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KEEMBAY_WATCHDOG                         policy<{'arm64': '-'}>
+CONFIG_KEMPLD_WDT                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KEXEC_FILE                               policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_KEXEC_IMAGE_VERIFY_SIG                   policy<{'arm64': '-'}>
+CONFIG_KEXEC_JUMP                               policy<{'amd64': '-'}>
+CONFIG_KEXEC_SIG                                policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_KEXEC_SIG_FORCE                          policy<{'amd64': '-'}>
+CONFIG_KEYBOARD_ADC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KEYBOARD_ADP5520                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KEYBOARD_ADP5588                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_ADP5589                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_APPLESPI                        policy<{'amd64': '-'}>
+CONFIG_KEYBOARD_BCM                             policy<{'arm64': 'n'}>
+CONFIG_KEYBOARD_CAP11XX                         policy<{'arm64': 'n'}>
+CONFIG_KEYBOARD_CROS_EC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KEYBOARD_DLINK_DIR685                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_GPIO                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_GPIO_POLLED                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_IMX                             policy<{'arm64': '-'}>
+CONFIG_KEYBOARD_IMX_SC_KEY                      policy<{'arm64': '-'}>
+CONFIG_KEYBOARD_IQS62X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KEYBOARD_LKKBD                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_LM8323                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_LM8333                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_MATRIX                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_MAX7359                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_MCS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_MPR121                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_MTK_PMIC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KEYBOARD_NEWTON                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_NVEC                            policy<{'arm64': '-'}>
+CONFIG_KEYBOARD_OMAP4                           policy<{'arm64': 'n'}>
+CONFIG_KEYBOARD_OPENCORES                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_QT1050                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_QT1070                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_QT2160                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_SAMSUNG                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_SNVS_PWRKEY                     policy<{'arm64': '-'}>
+CONFIG_KEYBOARD_STMPE                           policy<{'arm64': '-'}>
+CONFIG_KEYBOARD_STOWAWAY                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_SUN4I_LRADC                     policy<{'arm64': '-'}>
+CONFIG_KEYBOARD_SUNKBD                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_TC3589X                         policy<{'arm64': '-'}>
+CONFIG_KEYBOARD_TCA6416                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_TCA8418                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_TEGRA                           policy<{'arm64': 'n'}>
+CONFIG_KEYBOARD_TM2_TOUCHKEY                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYBOARD_TWL4030                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KEYBOARD_XTKBD                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEYS_REQUEST_CACHE                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KEY_NOTIFICATIONS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KFENCE                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KFENCE_NUM_OBJECTS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KFENCE_SAMPLE_INTERVAL                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KFENCE_STRESS_TEST_FAULTS                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KGDB                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_KGDB_HONOUR_BLOCKLIST                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KGDB_KDB                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KGDB_LOW_LEVEL_TRAP                      policy<{'amd64': '-'}>
+CONFIG_KGDB_TESTS                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KMX61                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KPROBE_EVENTS_ON_NOTRACE                 policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_KPSS_XCC                                 policy<{'arm64': '-'}>
+CONFIG_KS0108                                   policy<{'amd64': '-'}>
+CONFIG_KS0108_DELAY                             policy<{'amd64': '-'}>
+CONFIG_KS0108_PORT                              policy<{'amd64': '-'}>
+CONFIG_KS7010                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KS8842                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KS8851                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KS8851_MLL                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KSZ884X_PCI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KVM_AMD_SEV                              policy<{'amd64': '-'}>
+CONFIG_KVM_XEN                                  policy<{'amd64': 'n'}>
+CONFIG_KXCJK1013                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KXSD9                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KXSD9_I2C                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_KXSD9_SPI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_L2TP                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_L2TP_DEBUGFS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_L2TP_ETH                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_L2TP_IP                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_L2TP_V3                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LAN743X                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LANMEDIA                                 policy<{'amd64': '-'}>
+CONFIG_LAPB                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LAPBETHER                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LATTICE_ECP3_CONFIG                      policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_LCD2S                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_AMS369FG06                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_CLASS_DEVICE                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LCD_HX8357                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_ILI922X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_ILI9320                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_L4F00242T03                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_LMS283GF05                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_LMS501KF03                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_LTV350QV                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_OTM3225A                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_PLATFORM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_TDO24M                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LCD_VGG2432A4                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LDM_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LDM_PARTITION                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_88PM860X                            policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_LEDS_AAEON                               policy<{'amd64': '-'}>
+CONFIG_LEDS_AAT1290                             policy<{'arm64': '-'}>
+CONFIG_LEDS_ADP5520                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_AN30259A                            policy<{'arm64': 'n'}>
+CONFIG_LEDS_APU                                 policy<{'amd64': 'n'}>
+CONFIG_LEDS_AS3645A                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_AW2013                              policy<{'arm64': 'n'}>
+CONFIG_LEDS_BCM6328                             policy<{'arm64': 'n'}>
+CONFIG_LEDS_BCM6358                             policy<{'arm64': 'n'}>
+CONFIG_LEDS_BD2802                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_BLINKM                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_BRIGHTNESS_HW_CHANGED               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_CLASS_FLASH                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_CLASS_MULTICOLOR                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_CLEVO_MAIL                          policy<{'amd64': 'n'}>
+CONFIG_LEDS_CPCAP                               policy<{'arm64': '-'}>
+CONFIG_LEDS_CR0014114                           policy<{'arm64': 'n'}>
+CONFIG_LEDS_DA903X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_DA9052                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_DAC124S085                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_LEDS_EL15203000                          policy<{'arm64': 'n'}>
+CONFIG_LEDS_GPIO                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_INTEL_SS4200                        policy<{'amd64': 'n'}>
+CONFIG_LEDS_IS31FL319X                          policy<{'arm64': 'n'}>
+CONFIG_LEDS_IS31FL32XX                          policy<{'arm64': 'n'}>
+CONFIG_LEDS_KTD2692                             policy<{'arm64': '-'}>
+CONFIG_LEDS_LM3530                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_LM3532                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_LM3533                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_LM355x                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_LM3601X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_LM36274                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_LM3642                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_LM3692X                             policy<{'arm64': 'n'}>
+CONFIG_LEDS_LM3697                              policy<{'arm64': '-'}>
+CONFIG_LEDS_LP3944                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_LP3952                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_LP50XX                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_LEDS_LP5521                              policy<{'arm64': '-'}>
+CONFIG_LEDS_LP5523                              policy<{'arm64': '-'}>
+CONFIG_LEDS_LP5562                              policy<{'arm64': '-'}>
+CONFIG_LEDS_LP55XX_COMMON                       policy<{'arm64': 'n'}>
+CONFIG_LEDS_LP8501                              policy<{'arm64': '-'}>
+CONFIG_LEDS_LP8788                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_LP8860                              policy<{'arm64': 'n'}>
+CONFIG_LEDS_LT3593                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_MAX77650                            policy<{'arm64': '-'}>
+CONFIG_LEDS_MAX77693                            policy<{'arm64': '-'}>
+CONFIG_LEDS_MAX8997                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_MC13783                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_MENF21BMC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_MLXCPLD                             policy<{'amd64': 'n'}>
+CONFIG_LEDS_MLXREG                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_MT6323                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_NIC78BX                             policy<{'amd64': 'n'}>
+CONFIG_LEDS_PCA9532                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_PCA9532_GPIO                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_PCA955X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_PCA955X_GPIO                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_PCA963X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_PWM                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_REGULATOR                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_RT4505                              policy<{'arm64': '-'}>
+CONFIG_LEDS_RT8515                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_SC27XX_BLTC                         policy<{'arm64': '-'}>
+CONFIG_LEDS_SGM3140                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_SPI_BYTE                            policy<{'arm64': 'n'}>
+CONFIG_LEDS_SYSCON                              policy<{'arm64': 'n'}>
+CONFIG_LEDS_TCA6507                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_TI_LMU_COMMON                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_TLC591XX                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_TPS6105X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGERS                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_TRIGGER_ACTIVITY                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_AUDIO                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_BACKLIGHT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_CAMERA                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_CPU                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_DEFAULT_ON                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_DISK                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_GPIO                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_HEARTBEAT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_MTD                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_NETDEV                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_ONESHOT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_PANIC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_PATTERN                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_TIMER                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_TRANSIENT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_TRIGGER_TTY                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_USER                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEDS_WM831X_STATUS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEDS_WM8350                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LED_TRIGGER_PHY                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LEGACY_PTYS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LEGACY_PTY_COUNT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LG_LAPTOP                                policy<{'amd64': '-'}>
+CONFIG_LIB80211                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIB80211_CRYPT_CCMP                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIB80211_CRYPT_TKIP                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIB80211_CRYPT_WEP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIB80211_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS_CS                              policy<{'amd64': '-'}>
+CONFIG_LIBERTAS_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS_MESH                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS_SDIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS_SPI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS_THINFIRM                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS_THINFIRM_DEBUG                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS_THINFIRM_USB                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBERTAS_USB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBIPW                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBIPW_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIBNVDIMM                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LIDAR_LITE_V2                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LIQUIDIO                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LIQUIDIO_VF                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LIRC                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LITEX                                    policy<{'arm64': '-'}>
+CONFIG_LITEX_LITEETH                            policy<{'arm64': 'n'}>
+CONFIG_LITEX_SOC_CONTROLLER                     policy<{'arm64': 'n'}>
+CONFIG_LIVEPATCH                                policy<{'amd64': 'n'}>
+CONFIG_LLC2                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LMK04832                                 policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_LMP91000                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LOAD_UEFI_KEYS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LOGIG940_FF                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LOGIRUMBLEPAD2_FF                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LOGITECH_FF                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LOGIWHEELS_FF                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LP8788_ADC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LPC_ICH                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LPC_SCH                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LP_CONSOLE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LSI_ET1011C_PHY                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LSM                                      policy<{'amd64': '"lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"', 'arm64': '"lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"'}>
+CONFIG_LSM_MMAP_MIN_ADDR                        policy<{'amd64': '65536', 'arm64': '32768'}>
+CONFIG_LS_EXTIRQ                                policy<{'arm64': '-'}>
+CONFIG_LS_SCFG_MSI                              policy<{'arm64': '-'}>
+CONFIG_LTC1660                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LTC2471                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LTC2485                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LTC2496                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LTC2497                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LTC2632                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LTC2983                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LTE_GDM724X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LTPC                                     policy<{'amd64': '-'}>
+CONFIG_LTR501                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LV0104CS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LXT_PHY                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_LZ4HC_COMPRESS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LZ4_COMPRESS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_LZO_COMPRESS                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_M62332                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_DEBUGFS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_DEBUG_MENU                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_HAS_RC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_HWSIM                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_LEDS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_MESH                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_MESSAGE_TRACING                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_RC_DEFAULT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_RC_DEFAULT_MINSTREL             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_RC_MINSTREL                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC80211_STA_HASH_MAX_SIZE               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAC802154                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MACB                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MACB_PCI                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MACB_USE_HWSTAMP                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MACHZ_WDT                                policy<{'amd64': 'n'}>
+CONFIG_MACINTOSH_DRIVERS                        policy<{'amd64': 'n'}>
+CONFIG_MACSEC                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MAC_EMUMOUSEBTN                          policy<{'amd64': '-'}>
+CONFIG_MAC_PARTITION                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MADERA_IRQ                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAG3110                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAGIC_SYSRQ_DEFAULT_ENABLE               policy<{'amd64': '0x1', 'arm64': '0x1'}>
+CONFIG_MAILBOX_TEST                             policy<{'arm64': 'n'}>
+CONFIG_MANAGER_SBS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MANTIS_CORE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAPPING_DIRTY_HELPERS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MARVELL_10G_PHY                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MARVELL_88X2222_PHY                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MAX1027                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX11100                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX1118                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX1241                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX1363                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX30100                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX30102                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX31856                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX44000                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX44009                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX517                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX5432                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX5481                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX5487                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX5821                                  policy<{'arm64': '-'}>
+CONFIG_MAX63XX_WATCHDOG                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MAX77620_THERMAL                         policy<{'arm64': '-'}>
+CONFIG_MAX77620_WATCHDOG                        policy<{'arm64': '-'}>
+CONFIG_MAX8925_POWER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAX9611                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAXIM_THERMOCOUPLE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MAXLINEAR_GPHY                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MAXSMP                                   policy<{'amd64': 'n'}>
+CONFIG_MB1232                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MC3230                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCB                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MCB_LPC                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCB_PCI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP320X                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP3422                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP3911                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP4018                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP41010                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP4131                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP4531                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP4725                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCP4922                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MCTP                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MDIO_BCM_IPROC                           policy<{'arm64': 'y'}>
+CONFIG_MDIO_BCM_UNIMAC                          policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_MDIO_BITBANG                             policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_MDIO_BUS                                 policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_MDIO_BUS_MUX_GPIO                        policy<{'arm64': 'n'}>
+CONFIG_MDIO_BUS_MUX_MESON_G12A                  policy<{'arm64': '-'}>
+CONFIG_MDIO_BUS_MUX_MMIOREG                     policy<{'arm64': 'n'}>
+CONFIG_MDIO_BUS_MUX_MULTIPLEXER                 policy<{'arm64': 'n'}>
+CONFIG_MDIO_CAVIUM                              policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_MDIO_DEVICE                              policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_MDIO_DEVRES                              policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_MDIO_GPIO                                policy<{'amd64': '-', 'arm64': 'm'}>
+CONFIG_MDIO_HISI_FEMAC                          policy<{'arm64': 'n'}>
+CONFIG_MDIO_I2C                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MDIO_IPQ4019                             policy<{'arm64': 'n'}>
+CONFIG_MDIO_IPQ8064                             policy<{'arm64': 'n'}>
+CONFIG_MDIO_MSCC_MIIM                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MDIO_MVUSB                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MDIO_OCTEON                              policy<{'arm64': 'y'}>
+CONFIG_MDIO_SUN4I                               policy<{'arm64': '-'}>
+CONFIG_MDIO_THUNDER                             policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_MDIO_XGENE                               policy<{'arm64': 'y'}>
+CONFIG_MDM_GCC_9607                             policy<{'arm64': '-'}>
+CONFIG_MDM_GCC_9615                             policy<{'arm64': '-'}>
+CONFIG_MDM_LCC_9615                             policy<{'arm64': '-'}>
+CONFIG_MD_CLUSTER                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MD_FAULTY                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MD_MULTIPATH                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MEDIATEK_GE_PHY                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MEDIATEK_MT6360_ADC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIATEK_MT6577_AUXADC                   policy<{'arm64': '-'}>
+CONFIG_MEDIATEK_WATCHDOG                        policy<{'arm64': '-'}>
+CONFIG_MEDIA_ALTERA_CI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_ANALOG_TV_SUPPORT                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_ATTACH                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_CAMERA_SUPPORT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_CEC_RC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_CEC_SUPPORT                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MEDIA_COMMON_OPTIONS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_CONTROLLER                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_CONTROLLER_DVB                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_CONTROLLER_REQUEST_API             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_DIGITAL_TV_SUPPORT                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_PCI_SUPPORT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_PLATFORM_SUPPORT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_RADIO_SUPPORT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_SDR_SUPPORT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_SUBDRV_AUTOSELECT                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_SUPPORT                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MEDIA_SUPPORT_FILTER                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TEST_SUPPORT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_E4000                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_FC0011                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_FC0012                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_FC0013                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_FC2580                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_IT913X                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_M88RS6000T                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MAX2165                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MC44S803                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MSI001                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MT2060                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MT2063                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MT20XX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MT2131                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MT2266                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MXL301RF                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MXL5005S                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_MXL5007T                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_QM1D1B0004                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_QM1D1C0042                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_QT1010                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_R820T                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_SI2157                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_SIMPLE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TDA18212                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TDA18218                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TDA18250                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TDA18271                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TDA827X                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TDA8290                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TDA9887                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TEA5761                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TEA5767                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_TUA9001                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_XC2028                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_XC4000                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_TUNER_XC5000                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEDIA_USB_SUPPORT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEGARAID_LEGACY                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MELLANOX_PLATFORM                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MEMORY                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MEMORY_FAILURE                           policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_MEMORY_HOTPLUG                           policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_MEMORY_HOTPLUG_SPARSE                    policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MEMORY_HOTREMOVE                         policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MEMORY_ISOLATION                         policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MEMORY_NOTIFIER_ERROR_INJECT             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEMREGION                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEMSTICK                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MEMSTICK_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEMSTICK_JMICRON_38X                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEMSTICK_R592                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEMSTICK_REALTEK_PCI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEMSTICK_REALTEK_USB                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEMSTICK_TIFM_MS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEMSTICK_UNSAFE_RESUME                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MENF21BMC_WATCHDOG                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MENZ069_WATCHDOG                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MEN_A21_WDT                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MEN_Z188_ADC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MERAKI_MX100                             policy<{'amd64': '-'}>
+CONFIG_MESON_CANVAS                             policy<{'arm64': '-'}>
+CONFIG_MESON_CLK_MEASURE                        policy<{'arm64': '-'}>
+CONFIG_MESON_EE_PM_DOMAINS                      policy<{'arm64': '-'}>
+CONFIG_MESON_EFUSE                              policy<{'arm64': '-'}>
+CONFIG_MESON_GXBB_WATCHDOG                      policy<{'arm64': '-'}>
+CONFIG_MESON_GXL_PHY                            policy<{'arm64': '-'}>
+CONFIG_MESON_GX_PM_DOMAINS                      policy<{'arm64': '-'}>
+CONFIG_MESON_GX_SOCINFO                         policy<{'arm64': '-'}>
+CONFIG_MESON_IRQ_GPIO                           policy<{'arm64': '-'}>
+CONFIG_MESON_MX_EFUSE                           policy<{'arm64': '-'}>
+CONFIG_MESON_SARADC                             policy<{'arm64': '-'}>
+CONFIG_MESON_SECURE_PM_DOMAINS                  policy<{'arm64': '-'}>
+CONFIG_MESON_SM                                 policy<{'arm64': '-'}>
+CONFIG_MESON_WATCHDOG                           policy<{'arm64': '-'}>
+CONFIG_MFD_88PM800                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_88PM805                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_88PM860X                             policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_MFD_AAEON                                policy<{'amd64': '-'}>
+CONFIG_MFD_AAT2870_CORE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_AC100                                policy<{'arm64': '-'}>
+CONFIG_MFD_ACT8945A                             policy<{'arm64': 'n'}>
+CONFIG_MFD_ALTERA_A10SR                         policy<{'arm64': '-'}>
+CONFIG_MFD_ALTERA_SYSMGR                        policy<{'arm64': '-'}>
+CONFIG_MFD_ARIZONA                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_ARIZONA_I2C                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_ARIZONA_SPI                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MFD_AS3711                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_AS3722                               policy<{'arm64': '-'}>
+CONFIG_MFD_ATC260X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_ATC260X_I2C                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_ATMEL_FLEXCOM                        policy<{'arm64': 'n'}>
+CONFIG_MFD_ATMEL_HLCDC                          policy<{'arm64': 'n'}>
+CONFIG_MFD_AXP20X                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_AXP20X_I2C                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_AXP20X_RSB                           policy<{'arm64': '-'}>
+CONFIG_MFD_BCM590XX                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_BD9571MWV                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_CORE                                 policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_MFD_CPCAP                                policy<{'arm64': 'n'}>
+CONFIG_MFD_CROS_EC_DEV                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_CS47L15                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_CS47L24                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_CS47L35                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_CS47L85                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_CS47L90                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_CS47L92                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_DA9052_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_DA9052_SPI                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MFD_DA9055                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_DA9062                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_DA9063                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_DA9150                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_DLN2                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_GATEWORKS_GSC                        policy<{'arm64': 'n'}>
+CONFIG_MFD_HI6421_PMIC                          policy<{'arm64': 'n'}>
+CONFIG_MFD_HI6421_SPMI                          policy<{'arm64': '-'}>
+CONFIG_MFD_HI655X_PMIC                          policy<{'arm64': '-'}>
+CONFIG_MFD_INTEL_LPSS                           policy<{'amd64': '-'}>
+CONFIG_MFD_INTEL_LPSS_ACPI                      policy<{'amd64': 'n'}>
+CONFIG_MFD_INTEL_LPSS_PCI                       policy<{'amd64': 'n'}>
+CONFIG_MFD_INTEL_M10_BMC                        policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MFD_INTEL_PMC_BXT                        policy<{'amd64': 'n'}>
+CONFIG_MFD_INTEL_PMT                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_INTEL_QUARK_I2C_GPIO                 policy<{'amd64': 'n'}>
+CONFIG_MFD_IQS62X                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_JANZ_CMODIO                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_KEMPLD                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_LJCA                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_LM3533                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_LOCHNAGAR                            policy<{'arm64': '-'}>
+CONFIG_MFD_LP3943                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_LP8788                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_MADERA                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_MADERA_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_MADERA_SPI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_MAX14577                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_MAX77620                             policy<{'arm64': '-'}>
+CONFIG_MFD_MAX77650                             policy<{'arm64': 'n'}>
+CONFIG_MFD_MAX77686                             policy<{'arm64': 'n'}>
+CONFIG_MFD_MAX77693                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_MAX77843                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_MAX8907                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_MAX8925                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_MAX8997                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_MAX8998                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_MC13XXX                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_MC13XXX_I2C                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_MC13XXX_SPI                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MFD_MENF21BMC                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_MP2629                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_MT6360                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_MT6397                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_NTXEC                                policy<{'arm64': 'n'}>
+CONFIG_MFD_NVEC                                 policy<{'arm64': '-'}>
+CONFIG_MFD_PALMAS                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_PCF50633                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_QCOM_PM8008                          policy<{'arm64': 'n'}>
+CONFIG_MFD_QCOM_RPM                             policy<{'arm64': '-'}>
+CONFIG_MFD_RC5T583                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_RDC321X                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_RETU                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_RK808                                policy<{'arm64': 'n'}>
+CONFIG_MFD_RN5T618                              policy<{'arm64': 'n'}>
+CONFIG_MFD_ROHM_BD70528                         policy<{'arm64': '-'}>
+CONFIG_MFD_ROHM_BD71828                         policy<{'arm64': '-'}>
+CONFIG_MFD_ROHM_BD718XX                         policy<{'arm64': '-'}>
+CONFIG_MFD_ROHM_BD957XMUF                       policy<{'arm64': '-'}>
+CONFIG_MFD_RSMU_I2C                             policy<{'arm64': 'n'}>
+CONFIG_MFD_RSMU_SPI                             policy<{'arm64': 'n'}>
+CONFIG_MFD_RT4831                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_RT5033                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_SC27XX_PMIC                          policy<{'arm64': 'n'}>
+CONFIG_MFD_SEC_CORE                             policy<{'arm64': '-'}>
+CONFIG_MFD_SI476X_CORE                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_SIMPLE_MFD_I2C                       policy<{'arm64': '-'}>
+CONFIG_MFD_SKY81452                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_SL28CPLD                             policy<{'arm64': '-'}>
+CONFIG_MFD_SM501_GPIO                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_SPMI_PMIC                            policy<{'arm64': '-'}>
+CONFIG_MFD_STMFX                                policy<{'arm64': 'n'}>
+CONFIG_MFD_STMPE                                policy<{'arm64': 'n'}>
+CONFIG_MFD_STPMIC1                              policy<{'arm64': '-'}>
+CONFIG_MFD_SUN4I_GPADC                          policy<{'arm64': '-'}>
+CONFIG_MFD_SUN6I_PRCM                           policy<{'arm64': '-'}>
+CONFIG_MFD_SYSCON                               policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_MFD_TC3589X                              policy<{'arm64': '-'}>
+CONFIG_MFD_TI_AM335X_TSCADC                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_TI_LMU                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_TI_LP873X                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_TI_LP87565                           policy<{'arm64': 'n'}>
+CONFIG_MFD_TPS65086                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_TPS65090                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_TPS65218                             policy<{'arm64': 'n'}>
+CONFIG_MFD_TPS6586X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_TPS65910                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_TPS65912                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_TPS65912_I2C                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_TPS65912_SPI                         policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MFD_TPS80031                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_TQMX86                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_TWL4030_AUDIO                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_VIPERBOARD                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_VX855                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_WCD934X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WL1273_CORE                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_WM5102                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WM5110                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WM831X                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WM831X_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WM831X_SPI                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MFD_WM8350                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WM8350_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WM8400                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WM8994                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MFD_WM8997                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MFD_WM8998                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MHI_BUS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MHI_BUS_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MHI_BUS_PCI_GENERIC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MHI_NET                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MHI_WWAN_CTRL                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MHI_WWAN_MBIM                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MHP_MEMMAP_ON_MEMORY                     policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MICREL_KS8995MA                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MICREL_PHY                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MICROCHIP_PHY                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MICROCHIP_PIT64B                         policy<{'arm64': 'n'}>
+CONFIG_MICROCHIP_T1_PHY                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MICROCHIP_TCB_CAPTURE                    policy<{'arm64': '-'}>
+CONFIG_MICROSEMI_PHY                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MII                                      policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_MINIX_FS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MIPI_I3C_HCI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISC_ALCOR_PCI                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MISC_RTSX                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISC_RTSX_PCI                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MISC_RTSX_USB                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MISDN                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_AVMFRITZ                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_DSP                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_HDLC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_HFCMULTI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_HFCPCI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_HFCUSB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_INFINEON                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_IPAC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_ISAR                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_L1OIP                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_NETJET                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_SPEEDFAX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MISDN_W6692                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MKISS                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX4_DEBUG                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MLX4_INFINIBAND                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_ACCEL                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_CLS_ACT                             policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_MLX5_CORE_IPOIB                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MLX5_EN_IPSEC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_EN_TLS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_FPGA                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MLX5_FPGA_IPSEC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_FPGA_TLS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_INFINIBAND                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_IPSEC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_SF                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MLX5_SF_MANAGER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_SW_STEERING                         policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_MLX5_TC_CT                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_TC_SAMPLE                           policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MLX5_TLS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_VDPA                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX5_VDPA_NET                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX90614                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLX90632                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLXBF_BOOTCTL                            policy<{'arm64': '-'}>
+CONFIG_MLXBF_GIGE                               policy<{'arm64': 'n'}>
+CONFIG_MLXBF_PMC                                policy<{'arm64': '-'}>
+CONFIG_MLXBF_TMFIFO                             policy<{'arm64': '-'}>
+CONFIG_MLXFW                                    policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_MLXREG_HOTPLUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLXREG_IO                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MLXSW_CORE                               policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_MLXSW_CORE_HWMON                         policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MLXSW_CORE_THERMAL                       policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MLXSW_I2C                                policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_MLXSW_MINIMAL                            policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_MLXSW_PCI                                policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_MLXSW_SPECTRUM                           policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_MLXSW_SPECTRUM_DCB                       policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_MLX_PLATFORM                             policy<{'amd64': 'n'}>
+CONFIG_MLX_WDT                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMA7455                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMA7455_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMA7455_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMA7660                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMA8452                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMA9551                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMA9551_CORE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMA9553                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMC                                      policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_MMC35240                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMC_ALCOR                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMC_ARMMMCI                              policy<{'arm64': 'm'}>
+CONFIG_MMC_BCM2835                              policy<{'arm64': 'n'}>
+CONFIG_MMC_BLOCK_MINORS                         policy<{'amd64': '16', 'arm64': '16'}>
+CONFIG_MMC_CAVIUM_THUNDERX                      policy<{'arm64': '-'}>
+CONFIG_MMC_CB710                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_CRYPTO                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMC_DW                                   policy<{'arm64': 'n'}>
+CONFIG_MMC_DW_BLUEFIELD                         policy<{'arm64': '-'}>
+CONFIG_MMC_DW_EXYNOS                            policy<{'arm64': '-'}>
+CONFIG_MMC_DW_HI3798CV200                       policy<{'arm64': '-'}>
+CONFIG_MMC_DW_K3                                policy<{'arm64': '-'}>
+CONFIG_MMC_DW_PCI                               policy<{'arm64': '-'}>
+CONFIG_MMC_DW_PLTFM                             policy<{'arm64': '-'}>
+CONFIG_MMC_DW_ROCKCHIP                          policy<{'arm64': '-'}>
+CONFIG_MMC_HSQ                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_MESON_GX                             policy<{'arm64': '-'}>
+CONFIG_MMC_MESON_MX_SDIO                        policy<{'arm64': '-'}>
+CONFIG_MMC_MTK                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_MXC                                  policy<{'arm64': '-'}>
+CONFIG_MMC_OWL                                  policy<{'arm64': '-'}>
+CONFIG_MMC_QCOM_DML                             policy<{'arm64': '-'}>
+CONFIG_MMC_REALTEK_PCI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMC_REALTEK_USB                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MMC_RICOH_MMC                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_SDHCI_ACPI                           policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_MMC_SDHCI_AM654                          policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_BRCMSTB                        policy<{'arm64': '-'}>
+CONFIG_MMC_SDHCI_CADENCE                        policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_ESDHC_IMX                      policy<{'arm64': '-'}>
+CONFIG_MMC_SDHCI_EXTERNAL_DMA                   policy<{'arm64': '-'}>
+CONFIG_MMC_SDHCI_F_SDH30                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_SDHCI_MILBEAUT                       policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_MSM                            policy<{'arm64': '-'}>
+CONFIG_MMC_SDHCI_OF_ARASAN                      policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_OF_ASPEED                      policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_OF_AT91                        policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_OF_DWCMSHC                     policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_OF_ESDHC                       policy<{'arm64': '-'}>
+CONFIG_MMC_SDHCI_OF_SPARX5                      policy<{'arm64': '-'}>
+CONFIG_MMC_SDHCI_OMAP                           policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_PXAV3                          policy<{'arm64': '-'}>
+CONFIG_MMC_SDHCI_SPRD                           policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_TEGRA                          policy<{'arm64': 'n'}>
+CONFIG_MMC_SDHCI_XENON                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_SDHI                                 policy<{'arm64': '-'}>
+CONFIG_MMC_SDHI_INTERNAL_DMAC                   policy<{'arm64': '-'}>
+CONFIG_MMC_SDHI_SYS_DMAC                        policy<{'arm64': '-'}>
+CONFIG_MMC_SDRICOH_CS                           policy<{'amd64': '-'}>
+CONFIG_MMC_SH_MMCIF                             policy<{'arm64': '-'}>
+CONFIG_MMC_SPI                                  policy<{'amd64': '-', 'arm64': 'm'}>
+CONFIG_MMC_SUNXI                                policy<{'arm64': '-'}>
+CONFIG_MMC_TIFM_SD                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_TMIO_CORE                            policy<{'arm64': '-'}>
+CONFIG_MMC_TOSHIBA_PCI                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_USDHI6ROL0                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_USHC                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_VIA_SDMMC                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_VUB300                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MMC_WBSD                                 policy<{'amd64': 'n'}>
+CONFIG_MMIOTRACE                                policy<{'amd64': 'n'}>
+CONFIG_MMIOTRACE_TEST                           policy<{'amd64': '-'}>
+CONFIG_MOST                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOST_CDEV                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOST_COMPONENTS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOST_DIM2                                policy<{'arm64': '-'}>
+CONFIG_MOST_I2C                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOST_NET                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOST_SND                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOST_USB_HDM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOST_VIDEO                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOTORCOMM_PHY                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_APPLETOUCH                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_BCM5974                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_CYAPA                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_ELAN_I2C                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_ELAN_I2C_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOUSE_ELAN_I2C_SMBUS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOUSE_GPIO                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_ALPS                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_CYPRESS                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_ELANTECH                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_ELANTECH_SMBUS                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOUSE_PS2_FOCALTECH                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_LIFEBOOK                       policy<{'amd64': 'n'}>
+CONFIG_MOUSE_PS2_LOGIPS2PP                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_SENTELIC                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_SYNAPTICS                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_TOUCHKIT                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_TRACKPOINT                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_PS2_VMMOUSE                        policy<{'amd64': 'n'}>
+CONFIG_MOUSE_SERIAL                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_SYNAPTICS_I2C                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_SYNAPTICS_USB                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOUSE_VSXXXAA                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MOXA_INTELLIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOXA_SMARTIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MOXTET                                   policy<{'arm64': 'n'}>
+CONFIG_MP2629_ADC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MPL115                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MPL115_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MPL115_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MPL3115                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MPTCP                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MPTCP_IPV6                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MPU3050                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MPU3050_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MQ_IOSCHED_KYBER                         policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_MS5611                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MS5611_I2C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MS5611_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MS5637                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MSCC_OCELOT_SWITCH                       policy<{'arm64': 'n'}>
+CONFIG_MSCC_OCELOT_SWITCH_LIB                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MSI_LAPTOP                               policy<{'amd64': '-'}>
+CONFIG_MSI_WMI                                  policy<{'amd64': '-'}>
+CONFIG_MSM_GCC_8660                             policy<{'arm64': '-'}>
+CONFIG_MSM_GCC_8916                             policy<{'arm64': '-'}>
+CONFIG_MSM_GCC_8939                             policy<{'arm64': '-'}>
+CONFIG_MSM_GCC_8953                             policy<{'arm64': '-'}>
+CONFIG_MSM_GCC_8960                             policy<{'arm64': '-'}>
+CONFIG_MSM_GCC_8974                             policy<{'arm64': '-'}>
+CONFIG_MSM_GCC_8994                             policy<{'arm64': '-'}>
+CONFIG_MSM_GCC_8996                             policy<{'arm64': '-'}>
+CONFIG_MSM_GCC_8998                             policy<{'arm64': '-'}>
+CONFIG_MSM_GPUCC_8998                           policy<{'arm64': '-'}>
+CONFIG_MSM_LCC_8960                             policy<{'arm64': '-'}>
+CONFIG_MSM_MMCC_8960                            policy<{'arm64': '-'}>
+CONFIG_MSM_MMCC_8974                            policy<{'arm64': '-'}>
+CONFIG_MSM_MMCC_8994                            policy<{'arm64': '-'}>
+CONFIG_MSM_MMCC_8996                            policy<{'arm64': '-'}>
+CONFIG_MSM_MMCC_8998                            policy<{'arm64': '-'}>
+CONFIG_MSPRO_BLOCK                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MST_IRQ                                  policy<{'arm64': '-'}>
+CONFIG_MS_BLOCK                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7601U                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7603E                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7615E                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7615_COMMON                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7622_WMAC                              policy<{'arm64': '-'}>
+CONFIG_MT7663S                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7663U                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7663_USB_SDIO_COMMON                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76_CONNAC_LIB                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76_CORE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76_LEDS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76_SDIO                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76_USB                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76x02_LIB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76x02_USB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76x0E                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76x0U                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76x0_COMMON                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76x2E                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76x2U                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT76x2_COMMON                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7915E                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MT7921E                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTDRAM_ERASE_SIZE                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTDRAM_TOTAL_SIZE                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_ABSENT                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_AFS_PARTS                            policy<{'arm64': 'n'}>
+CONFIG_MTD_AMD76XROM                            policy<{'amd64': '-'}>
+CONFIG_MTD_AR7_PARTS                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_BLKDEVS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_BLOCK2MTD                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_BLOCK_RO                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_CFI                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_CFI_ADV_OPTIONS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_CFI_AMDSTD                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_CFI_INTELEXT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_CFI_STAA                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_CFI_UTIL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_CK804XROM                            policy<{'amd64': '-'}>
+CONFIG_MTD_CMDLINE_PARTS                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_COMPLEX_MAPPINGS                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_DATAFLASH                            policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MTD_DATAFLASH_OTP                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_DATAFLASH_WRITE_VERIFY               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_ESB2ROM                              policy<{'amd64': '-'}>
+CONFIG_MTD_GEN_PROBE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_HYPERBUS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_ICHXROM                              policy<{'amd64': '-'}>
+CONFIG_MTD_INTEL_VR_NOR                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_JEDECPROBE                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_L440GX                               policy<{'amd64': '-'}>
+CONFIG_MTD_LPDDR                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_MCHP23K256                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MTD_MCHP48L640                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MTD_MTDRAM                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_NAND_ARASAN                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_BRCMNAND                        policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_CADENCE                         policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_CAFE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_CORE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_DENALI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_DENALI_DT                       policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_DENALI_PCI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_DISKONCHIP                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_DISKONCHIP_PROBE_ADDRESS        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_DISKONCHIP_PROBE_ADVANCED       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_ECC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_ECC_SW_BCH                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_NAND_ECC_SW_HAMMING                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_NAND_ECC_SW_HAMMING_SMC              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_FSL_IFC                         policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_GPIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_GPMI_NAND                       policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_HISI504                         policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_INTEL_LGM                       policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_MARVELL                         policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_MESON                           policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_MTK                             policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_MXC                             policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_MXIC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_NANDSIM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_PLATFORM                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_QCOM                            policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_RICOH                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_NAND_ROCKCHIP                        policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_SUNXI                           policy<{'arm64': '-'}>
+CONFIG_MTD_NAND_TEGRA                           policy<{'arm64': '-'}>
+CONFIG_MTD_NETtel                               policy<{'amd64': '-'}>
+CONFIG_MTD_OF_PARTS_BCM4908                     policy<{'arm64': '-'}>
+CONFIG_MTD_OF_PARTS_LINKSYS_NS                  policy<{'arm64': '-'}>
+CONFIG_MTD_ONENAND                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_ONENAND_2X_PROGRAM                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_ONENAND_GENERIC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_ONENAND_OTP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_OOPS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_PARSER_TRX                           policy<{'arm64': '-'}>
+CONFIG_MTD_PCI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_PCMCIA                               policy<{'amd64': '-'}>
+CONFIG_MTD_PCMCIA_ANONYMOUS                     policy<{'amd64': '-'}>
+CONFIG_MTD_PHRAM                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_PHYSMAP                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_PHYSMAP_COMPAT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_PHYSMAP_GEMINI                       policy<{'arm64': '-'}>
+CONFIG_MTD_PHYSMAP_GPIO_ADDR                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_PHYSMAP_OF                           policy<{'arm64': '-'}>
+CONFIG_MTD_PHYSMAP_VERSATILE                    policy<{'arm64': '-'}>
+CONFIG_MTD_PLATRAM                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_PMC551                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_PMC551_BUGFIX                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_PMC551_DEBUG                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_PSTORE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_QCOMSMEM_PARTS                       policy<{'arm64': '-'}>
+CONFIG_MTD_QINFO_PROBE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_RAM                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_REDBOOT_DIRECTORY_BLOCK              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_REDBOOT_PARTS                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_REDBOOT_PARTS_READONLY               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_REDBOOT_PARTS_UNALLOCATED            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_ROM                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_SBC_GXX                              policy<{'amd64': '-'}>
+CONFIG_MTD_SCB2_FLASH                           policy<{'amd64': '-'}>
+CONFIG_MTD_SLRAM                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_SM_COMMON                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_SPI_NAND                             policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MTD_SPI_NOR                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MTD_SPI_NOR_SWP_DISABLE                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_SPI_NOR_SWP_DISABLE_ON_VOLATILE      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_SPI_NOR_SWP_KEEP                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_SPI_NOR_USE_4K_SECTORS               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_SST25L                               policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_MTD_SWAP                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_UBI                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MTD_UBI_BEB_LIMIT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_UBI_BLOCK                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_UBI_FASTMAP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_UBI_GLUEBI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTD_UBI_WL_THRESHOLD                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MTK_CMDQ                                 policy<{'arm64': '-'}>
+CONFIG_MTK_CMDQ_MBOX                            policy<{'arm64': '-'}>
+CONFIG_MTK_CQDMA                                policy<{'arm64': '-'}>
+CONFIG_MTK_DEVAPC                               policy<{'arm64': '-'}>
+CONFIG_MTK_EFUSE                                policy<{'arm64': '-'}>
+CONFIG_MTK_HSDMA                                policy<{'arm64': '-'}>
+CONFIG_MTK_INFRACFG                             policy<{'arm64': '-'}>
+CONFIG_MTK_IOMMU                                policy<{'arm64': '-'}>
+CONFIG_MTK_MMSYS                                policy<{'arm64': '-'}>
+CONFIG_MTK_PMIC_WRAP                            policy<{'arm64': '-'}>
+CONFIG_MTK_SCP                                  policy<{'arm64': '-'}>
+CONFIG_MTK_SCPSYS                               policy<{'arm64': '-'}>
+CONFIG_MTK_SCPSYS_PM_DOMAINS                    policy<{'arm64': '-'}>
+CONFIG_MTK_SMI                                  policy<{'arm64': '-'}>
+CONFIG_MTK_THERMAL                              policy<{'arm64': '-'}>
+CONFIG_MTK_TIMER                                policy<{'arm64': '-'}>
+CONFIG_MTK_UART_APDMA                           policy<{'arm64': '-'}>
+CONFIG_MULTIPLEXER                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MUSB_PIO_ONLY                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MUX_ADG792A                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MUX_ADGS1408                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MUX_GPIO                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MUX_MMIO                                 policy<{'arm64': '-'}>
+CONFIG_MVEBU_GICP                               policy<{'arm64': '-'}>
+CONFIG_MVEBU_ICU                                policy<{'arm64': '-'}>
+CONFIG_MVEBU_ODMI                               policy<{'arm64': '-'}>
+CONFIG_MVEBU_PIC                                policy<{'arm64': '-'}>
+CONFIG_MVEBU_SEI                                policy<{'arm64': '-'}>
+CONFIG_MVMDIO                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_MVNETA                                   policy<{'arm64': '-'}>
+CONFIG_MVPP2                                    policy<{'arm64': '-'}>
+CONFIG_MVPP2_PTP                                policy<{'arm64': '-'}>
+CONFIG_MV_XOR                                   policy<{'arm64': '-'}>
+CONFIG_MV_XOR_V2                                policy<{'arm64': 'n'}>
+CONFIG_MWAVE                                    policy<{'amd64': 'n'}>
+CONFIG_MWIFIEX                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MWIFIEX_PCIE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MWIFIEX_SDIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MWIFIEX_USB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MWL8K                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MX3_IPU                                  policy<{'arm64': '-'}>
+CONFIG_MX3_IPU_IRQS                             policy<{'arm64': '-'}>
+CONFIG_MXC4005                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MXC6255                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_MXC_CLK                                  policy<{'arm64': '-'}>
+CONFIG_MXC_CLK_SCU                              policy<{'arm64': '-'}>
+CONFIG_MXM_WMI                                  policy<{'amd64': '-'}>
+CONFIG_MXS_DMA                                  policy<{'arm64': '-'}>
+CONFIG_NATIONAL_PHY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NAU7802                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NCSI_OEM_CMD_GET_MAC                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NCSI_OEM_CMD_KEEP_PHY                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NDC_DIS_DYNAMIC_CACHING                  policy<{'arm64': '-'}>
+CONFIG_ND_BLK                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ND_BTT                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ND_CLAIM                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ND_PFN                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NE2K_PCI                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NETDEVSIM                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NETDEV_NOTIFIER_ERROR_INJECT             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NETFILTER_NETLINK_HOOK                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NETFILTER_XTABLES                        policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_NETFILTER_XT_MATCH_SCTP                  policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_NETFILTER_XT_TARGET_AUDIT                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NETFILTER_XT_TARGET_LED                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NETLABEL                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NETROM                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_9P_RDMA                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_9P_XEN                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_BPF                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_CONNMARK                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_CT                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_ACT_CTINFO                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_GATE                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_MPLS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_SAMPLE                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_SIMP                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_SKBMOD                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_ACT_TUNNEL_KEY                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_CLS_FLOWER                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_CLS_MATCHALL                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_DSA                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_DSA_AR9331                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_BCM_SF2                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_HIRSCHMANN_HELLCREEK             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_LANTIQ_GSWIP                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_LOOP                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MICROCHIP_KSZ8795                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MICROCHIP_KSZ8795_SPI            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MICROCHIP_KSZ8863_SMI            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MICROCHIP_KSZ9477                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MICROCHIP_KSZ9477_I2C            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MICROCHIP_KSZ9477_SPI            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MICROCHIP_KSZ_COMMON             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MSCC_FELIX                       policy<{'arm64': '-'}>
+CONFIG_NET_DSA_MSCC_SEVILLE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MT7530                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MV88E6060                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MV88E6XXX                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_MV88E6XXX_PTP                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_QCA8K                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_REALTEK_SMI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_SJA1105                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_SJA1105_PTP                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_SJA1105_TAS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_SJA1105_VL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_SMSC_LAN9303                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_SMSC_LAN9303_I2C                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_SMSC_LAN9303_MDIO                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_AR9331                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_BRCM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_BRCM_COMMON                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_BRCM_LEGACY                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_BRCM_PREPEND                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_DSA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_DSA_COMMON                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_EDSA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_GSWIP                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_HELLCREEK                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_KSZ                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_LAN9303                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_MTK                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_OCELOT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_OCELOT_8021Q                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_QCA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_RTL4_A                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_SJA1105                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_TRAILER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_TAG_XRS700X                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_VITESSE_VSC73XX                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_VITESSE_VSC73XX_PLATFORM         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_VITESSE_VSC73XX_SPI              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_XRS700X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_XRS700X_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_DSA_XRS700X_MDIO                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_EMATCH_CANID                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_EMATCH_IPT                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_FC                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_IFE                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_NCSI                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_PKTGEN                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SB1000                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SCH_ATM                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_SCH_CAKE                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SCH_CBS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SCH_ETF                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SCH_ETS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SCH_FQ_PIE                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SCH_SKBPRIO                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SCH_TAPRIO                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_SELFTESTS                            policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_NET_TC_SKB_EXT                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_TEAM                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_TEAM_MODE_ACTIVEBACKUP               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_TEAM_MODE_BROADCAST                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_TEAM_MODE_LOADBALANCE                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_TEAM_MODE_RANDOM                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_TEAM_MODE_ROUNDROBIN                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NET_VENDOR_3COM                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_ACTIONS                       policy<{'arm64': '-'}>
+CONFIG_NET_VENDOR_ADAPTEC                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_AGERE                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_ALLWINNER                     policy<{'arm64': '-'}>
+CONFIG_NET_VENDOR_ARC                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_CIRRUS                        policy<{'amd64': '-'}>
+CONFIG_NET_VENDOR_FREESCALE                     policy<{'arm64': '-'}>
+CONFIG_NET_VENDOR_FUJITSU                       policy<{'amd64': '-'}>
+CONFIG_NET_VENDOR_MEDIATEK                      policy<{'arm64': '-'}>
+CONFIG_NET_VENDOR_MICREL                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_OKI                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_QUALCOMM                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_RDC                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_ROCKER                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_SAMSUNG                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_SEEQ                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_SILAN                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_SIS                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_SMSC                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_STMICRO                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_SUN                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_TEHUTI                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_TI                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_WIZNET                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NET_VENDOR_XIRCOM                        policy<{'amd64': '-'}>
+CONFIG_NET_VRF                                  policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_NET_XGENE                                policy<{'arm64': 'y'}>
+CONFIG_NET_XGENE_V2                             policy<{'arm64': 'n'}>
+CONFIG_NFC                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFC_DIGITAL                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_FDP                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_FDP_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_HCI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_MEI_PHY                              policy<{'amd64': '-'}>
+CONFIG_NFC_MICROREAD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_MICROREAD_I2C                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_MICROREAD_MEI                        policy<{'amd64': '-'}>
+CONFIG_NFC_MRVL                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_MRVL_I2C                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_MRVL_SPI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_MRVL_UART                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_MRVL_USB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_NCI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_NCI_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_NCI_UART                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_NXP_NCI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_NXP_NCI_I2C                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_PN532_UART                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_PN533                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_PN533_I2C                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_PN533_USB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_PN544                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_PN544_I2C                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_PN544_MEI                            policy<{'amd64': '-'}>
+CONFIG_NFC_PORT100                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_S3FWRN5                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_S3FWRN5_I2C                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_S3FWRN82_UART                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_SHDLC                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_SIM                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_ST21NFCA                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_ST21NFCA_I2C                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_ST95HF                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_ST_NCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_ST_NCI_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_ST_NCI_SPI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_TRF7970A                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFC_VIRTUAL_NCI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFIT_SECURITY_DEBUG                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFP                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFP_APP_ABM_NIC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFP_APP_FLOWER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFP_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFSD_BLOCKLAYOUT                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFSD_FLEXFILELAYOUT                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFSD_PNFS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFSD_SCSILAYOUT                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFSD_V4_2_INTER_SSC                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFSD_V4_SECURITY_LABEL                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFS_SWAP                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFS_V4_1_MIGRATION                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFTL                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFTL_RW                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFT_CONNLIMIT                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFT_FLOW_OFFLOAD                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NFT_OSF                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFT_REJECT_NETDEV                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFT_SOCKET                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFT_SYNPROXY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFT_TPROXY                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFT_TUNNEL                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NFT_XFRM                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NF_CT_PROTO_SCTP                         policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_NF_FLOW_TABLE                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NF_FLOW_TABLE_INET                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NF_FLOW_TABLE_IPV4                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NF_FLOW_TABLE_IPV6                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NF_LOG_IPV4                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NI903X_WDT                               policy<{'amd64': 'n'}>
+CONFIG_NIC7018_WDT                              policy<{'amd64': 'n'}>
+CONFIG_NILFS2_FS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NITRO_ENCLAVES                           policy<{'amd64': 'n'}>
+CONFIG_NIU                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NI_XGE_MANAGEMENT_ENET                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NL80211_TESTMODE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NLMON                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_1250                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_1251                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_437                         policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_NLS_CODEPAGE_737                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_775                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_850                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_852                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_855                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_857                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_860                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_861                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_862                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_863                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_864                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_865                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_866                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_869                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_874                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_932                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_936                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_949                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_CODEPAGE_950                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_1                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_13                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_14                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_15                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_2                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_3                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_4                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_5                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_6                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_7                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_8                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_ISO8859_9                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_KOI8_R                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_KOI8_U                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_CELTIC                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_CENTEURO                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_CROATIAN                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_CYRILLIC                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_GAELIC                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_GREEK                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_ICELAND                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_INUIT                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_ROMAN                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_ROMANIAN                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NLS_MAC_TURKISH                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NOA1305                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NODES_SHIFT                              policy<{'amd64': '7', 'arm64': '7'}>
+CONFIG_NORTEL_HERMES                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NOTIFIER_ERROR_INJECTION                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NOUVEAU_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NOUVEAU_DEBUG_DEFAULT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NOUVEAU_DEBUG_MMU                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NOUVEAU_DEBUG_PUSH                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NOUVEAU_PLATFORM_DRIVER                  policy<{'arm64': '-'}>
+CONFIG_NOZOMI                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NR_CPUS_DEFAULT                          policy<{'amd64': '64'}>
+CONFIG_NR_CPUS_RANGE_BEGIN                      policy<{'amd64': '2'}>
+CONFIG_NR_CPUS_RANGE_END                        policy<{'amd64': '512'}>
+CONFIG_NS83820                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NTB                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NTB_AMD                                  policy<{'amd64': '-'}>
+CONFIG_NTB_EPF                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_IDT                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_INTEL                                policy<{'amd64': '-'}>
+CONFIG_NTB_MSI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_MSI_TEST                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_NETDEV                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_PERF                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_PINGPONG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_SWITCHTEC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_TOOL                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTB_TRANSPORT                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTFS3_64BIT_CLUSTER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTFS3_FS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NTFS3_FS_POSIX_ACL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTFS3_LZX_XPRESS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTFS_DEBUG                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NTFS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NTFS_RW                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NULL_TTY                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NUMA_KEEP_MEMINFO                        policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_NVDIMM_DAX                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NVDIMM_KEYS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NVDIMM_PFN                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NVEC_PAZ00                               policy<{'arm64': '-'}>
+CONFIG_NVEC_POWER                               policy<{'arm64': '-'}>
+CONFIG_NVIDIA_WMI_EC_BACKLIGHT                  policy<{'amd64': '-'}>
+CONFIG_NVMEM_BCM_OCOTP                          policy<{'arm64': 'y'}>
+CONFIG_NVMEM_IMX_IIM                            policy<{'arm64': '-'}>
+CONFIG_NVMEM_IMX_OCOTP                          policy<{'arm64': '-'}>
+CONFIG_NVMEM_IMX_OCOTP_SCU                      policy<{'arm64': '-'}>
+CONFIG_NVMEM_REBOOT_MODE                        policy<{'arm64': 'n'}>
+CONFIG_NVMEM_RMEM                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NVMEM_SNVS_LPGPR                         policy<{'arm64': '-'}>
+CONFIG_NVMEM_SPMI_SDAM                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NVMEM_SUNXI_SID                          policy<{'arm64': '-'}>
+CONFIG_NVMEM_ZYNQMP                             policy<{'arm64': '-'}>
+CONFIG_NVME_FC                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NVME_HWMON                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NVME_MULTIPATH                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NVME_RDMA                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NVME_TARGET_FC                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NVME_TARGET_FCLOOP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NVME_TARGET_PASSTHRU                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NVME_TARGET_RDMA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_NVME_TARGET_TCP                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NVME_TCP                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NV_TCO                                   policy<{'amd64': 'n'}>
+CONFIG_NXP_C45_TJA11XX_PHY                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_NXP_TJA11XX_PHY                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_N_HDLC                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_OBJAGG                                   policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_OCFS2_DEBUG_FS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_OCFS2_DEBUG_MASKLOG                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_OCFS2_FS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_OCFS2_FS_O2CB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_OCFS2_FS_STATS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_OCFS2_FS_USERSPACE_CLUSTER               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_OCTEONTX2_AF                             policy<{'arm64': 'n'}>
+CONFIG_OCTEONTX2_MBOX                           policy<{'arm64': '-'}>
+CONFIG_OCTEONTX2_PF                             policy<{'arm64': 'n'}>
+CONFIG_OCTEONTX2_VF                             policy<{'arm64': '-'}>
+CONFIG_OF_DYNAMIC                               policy<{'arm64': '-'}>
+CONFIG_OF_FPGA_REGION                           policy<{'arm64': '-'}>
+CONFIG_OF_OVERLAY                               policy<{'arm64': 'n'}>
+CONFIG_OF_PMEM                                  policy<{'arm64': '-'}>
+CONFIG_OF_RECONFIG_NOTIFIER_ERROR_INJECT        policy<{'arm64': '-'}>
+CONFIG_OF_RESOLVE                               policy<{'arm64': '-'}>
+CONFIG_OMAP2PLUS_MBOX                           policy<{'arm64': '-'}>
+CONFIG_OMAP_MBOX_KFIFO_SIZE                     policy<{'arm64': '-'}>
+CONFIG_OMAP_USB2                                policy<{'arm64': '-'}>
+CONFIG_OMFS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_OPT3001                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_OPTEE                                    policy<{'arm64': '-'}>
+CONFIG_OPTEE_SHM_NUM_PRIV_PAGES                 policy<{'arm64': '-'}>
+CONFIG_ORANGEFS_FS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ORINOCO_USB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_OSF_PARTITION                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_OVERLAY_FS_METACOPY                      policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_OVERLAY_FS_REDIRECT_DIR                  policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_OVERLAY_FS_XINO_AUTO                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_OWL_DMA                                  policy<{'arm64': '-'}>
+CONFIG_OWL_EMAC                                 policy<{'arm64': '-'}>
+CONFIG_OWL_PM_DOMAINS                           policy<{'arm64': '-'}>
+CONFIG_OWL_PM_DOMAINS_HELPER                    policy<{'arm64': '-'}>
+CONFIG_OWL_TIMER                                policy<{'arm64': '-'}>
+CONFIG_P54_COMMON                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_P54_LEDS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_P54_PCI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_P54_SPI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_P54_SPI_DEFAULT_EEPROM                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_P54_USB                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PA12203001                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PACKING                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PADATA                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PALMAS_GPADC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PANASONIC_LAPTOP                         policy<{'amd64': '-'}>
+CONFIG_PANEL                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PANEL_CHANGE_MESSAGE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PANEL_PARPORT                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PANEL_PROFILE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PANIC_ON_OOPS_VALUE                      policy<{'amd64': '1', 'arm64': '1'}>
+CONFIG_PANIC_TIMEOUT                            policy<{'amd64': '60', 'arm64': '60'}>
+CONFIG_PANTHERLORD_FF                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PARAVIRT_TIME_ACCOUNTING                 policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_PARIDE                                   policy<{'amd64': '-'}>
+CONFIG_PARIDE_ATEN                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_BPCK                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_COMM                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_DSTR                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_EPAT                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_EPATC8                            policy<{'amd64': '-'}>
+CONFIG_PARIDE_EPIA                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_FIT2                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_FIT3                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_FRIQ                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_FRPW                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_KBIC                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_KTTI                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_ON20                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_ON26                              policy<{'amd64': '-'}>
+CONFIG_PARIDE_PCD                               policy<{'amd64': '-'}>
+CONFIG_PARIDE_PD                                policy<{'amd64': '-'}>
+CONFIG_PARIDE_PF                                policy<{'amd64': '-'}>
+CONFIG_PARIDE_PG                                policy<{'amd64': '-'}>
+CONFIG_PARIDE_PT                                policy<{'amd64': '-'}>
+CONFIG_PARMAN                                   policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_PARPORT                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PARPORT_1284                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PARPORT_AX88796                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PARPORT_NOT_PC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PARPORT_PANEL                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PARPORT_PC                               policy<{'amd64': '-'}>
+CONFIG_PARPORT_PC_FIFO                          policy<{'amd64': '-'}>
+CONFIG_PARPORT_PC_PCMCIA                        policy<{'amd64': '-'}>
+CONFIG_PARPORT_PC_SUPERIO                       policy<{'amd64': '-'}>
+CONFIG_PARPORT_SERIAL                           policy<{'amd64': '-'}>
+CONFIG_PATA_ACPI                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_ALI                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_AMD                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_ARTOP                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_ATIIXP                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_ATP867X                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_CMD640_PCI                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_CMD64X                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_CYPRESS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_EFAR                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_HPT366                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_HPT37X                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_HPT3X2N                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_HPT3X3                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_IMX                                 policy<{'arm64': '-'}>
+CONFIG_PATA_IT8213                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_IT821X                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_LEGACY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_MARVELL                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_MPIIX                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_NETCELL                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_NINJA32                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_NS87410                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_NS87415                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_OLDPIIX                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_OPTI                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_OPTIDMA                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_PCMCIA                              policy<{'amd64': '-'}>
+CONFIG_PATA_PDC2027X                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_PDC_OLD                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_PLATFORM                            policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_PATA_RADISYS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_RDC                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_RZ1000                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_SCH                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_SERVERWORKS                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_SIL680                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_SIS                                 policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_PATA_TOSHIBA                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_TRIFLEX                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PATA_WINBOND                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PC104                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PC300TOO                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PC87413_WDT                              policy<{'amd64': 'n'}>
+CONFIG_PCC                                      policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_PCCARD                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PCCARD_NONSTATIC                         policy<{'amd64': '-'}>
+CONFIG_PCENGINES_APU2                           policy<{'amd64': 'n'}>
+CONFIG_PCF50633_ADC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCF50633_GPIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCI200SYN                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCIE_AL                                  policy<{'arm64': 'n'}>
+CONFIG_PCIE_ALTERA                              policy<{'arm64': 'n'}>
+CONFIG_PCIE_ALTERA_MSI                          policy<{'arm64': '-'}>
+CONFIG_PCIE_ARMADA_8K                           policy<{'arm64': '-'}>
+CONFIG_PCIE_BRCMSTB                             policy<{'arm64': 'n'}>
+CONFIG_PCIE_CADENCE                             policy<{'arm64': '-'}>
+CONFIG_PCIE_CADENCE_EP                          policy<{'arm64': '-'}>
+CONFIG_PCIE_CADENCE_HOST                        policy<{'arm64': '-'}>
+CONFIG_PCIE_CADENCE_PLAT                        policy<{'arm64': '-'}>
+CONFIG_PCIE_CADENCE_PLAT_EP                     policy<{'arm64': '-'}>
+CONFIG_PCIE_CADENCE_PLAT_HOST                   policy<{'arm64': 'n'}>
+CONFIG_PCIE_DPC                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PCIE_DW                                  policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_PCIE_DW_EP                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCIE_DW_HOST                             policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_PCIE_DW_PLAT                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCIE_DW_PLAT_EP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCIE_DW_PLAT_HOST                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PCIE_ECRC                                policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_PCIE_HISI_ERR                            policy<{'arm64': '-'}>
+CONFIG_PCIE_HISI_STB                            policy<{'arm64': '-'}>
+CONFIG_PCIE_IPROC                               policy<{'arm64': 'y'}>
+CONFIG_PCIE_IPROC_PLATFORM                      policy<{'arm64': 'y'}>
+CONFIG_PCIE_KEEMBAY                             policy<{'arm64': '-'}>
+CONFIG_PCIE_KEEMBAY_EP                          policy<{'arm64': '-'}>
+CONFIG_PCIE_KEEMBAY_HOST                        policy<{'arm64': '-'}>
+CONFIG_PCIE_KIRIN                               policy<{'arm64': 'n'}>
+CONFIG_PCIE_LAYERSCAPE_GEN4                     policy<{'arm64': '-'}>
+CONFIG_PCIE_MEDIATEK                            policy<{'arm64': '-'}>
+CONFIG_PCIE_MEDIATEK_GEN3                       policy<{'arm64': '-'}>
+CONFIG_PCIE_MICROCHIP_HOST                      policy<{'arm64': 'n'}>
+CONFIG_PCIE_MOBIVEIL_PLAT                       policy<{'arm64': '-'}>
+CONFIG_PCIE_PTM                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PCIE_QCOM                                policy<{'arm64': '-'}>
+CONFIG_PCIE_RCAR_EP                             policy<{'arm64': '-'}>
+CONFIG_PCIE_RCAR_HOST                           policy<{'arm64': '-'}>
+CONFIG_PCIE_ROCKCHIP_EP                         policy<{'arm64': '-'}>
+CONFIG_PCIE_TEGRA194                            policy<{'arm64': '-'}>
+CONFIG_PCIE_TEGRA194_EP                         policy<{'arm64': '-'}>
+CONFIG_PCIE_TEGRA194_HOST                       policy<{'arm64': '-'}>
+CONFIG_PCIE_VISCONTI_HOST                       policy<{'arm64': '-'}>
+CONFIG_PCIE_XILINX                              policy<{'arm64': 'n'}>
+CONFIG_PCIE_XILINX_CPM                          policy<{'arm64': '-'}>
+CONFIG_PCIE_XILINX_NWL                          policy<{'arm64': '-'}>
+CONFIG_PCIPCWATCHDOG                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PCI_AARDVARK                             policy<{'arm64': '-'}>
+CONFIG_PCI_ATMEL                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCI_BRIDGE_EMUL                          policy<{'arm64': '-'}>
+CONFIG_PCI_ENDPOINT                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PCI_ENDPOINT_CONFIGFS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCI_EPF_NTB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCI_EPF_TEST                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCI_FTPCI100                             policy<{'arm64': 'n'}>
+CONFIG_PCI_HYPERV                               policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_PCI_HYPERV_INTERFACE                     policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_PCI_IMX6                                 policy<{'arm64': '-'}>
+CONFIG_PCI_J721E                                policy<{'arm64': '-'}>
+CONFIG_PCI_J721E_EP                             policy<{'arm64': '-'}>
+CONFIG_PCI_J721E_HOST                           policy<{'arm64': 'n'}>
+CONFIG_PCI_KEYSTONE                             policy<{'arm64': '-'}>
+CONFIG_PCI_KEYSTONE_EP                          policy<{'arm64': '-'}>
+CONFIG_PCI_KEYSTONE_HOST                        policy<{'arm64': '-'}>
+CONFIG_PCI_LAYERSCAPE                           policy<{'arm64': '-'}>
+CONFIG_PCI_LAYERSCAPE_EP                        policy<{'arm64': '-'}>
+CONFIG_PCI_P2PDMA                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCI_PF_STUB                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PCI_REALLOC_ENABLE_AUTO                  policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_PCI_STUB                                 policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_PCI_SW_SWITCHTEC                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PCI_TEGRA                                policy<{'arm64': 'n'}>
+CONFIG_PCMCIA                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCMCIA_3C574                             policy<{'amd64': '-'}>
+CONFIG_PCMCIA_3C589                             policy<{'amd64': '-'}>
+CONFIG_PCMCIA_AHA152X                           policy<{'amd64': '-'}>
+CONFIG_PCMCIA_ATMEL                             policy<{'amd64': '-'}>
+CONFIG_PCMCIA_AXNET                             policy<{'amd64': '-'}>
+CONFIG_PCMCIA_FDOMAIN                           policy<{'amd64': '-'}>
+CONFIG_PCMCIA_FMVJ18X                           policy<{'amd64': '-'}>
+CONFIG_PCMCIA_HERMES                            policy<{'amd64': '-'}>
+CONFIG_PCMCIA_LOAD_CIS                          policy<{'amd64': '-'}>
+CONFIG_PCMCIA_NMCLAN                            policy<{'amd64': '-'}>
+CONFIG_PCMCIA_PCNET                             policy<{'amd64': '-'}>
+CONFIG_PCMCIA_QLOGIC                            policy<{'amd64': '-'}>
+CONFIG_PCMCIA_RAYCS                             policy<{'amd64': '-'}>
+CONFIG_PCMCIA_SMC91C92                          policy<{'amd64': '-'}>
+CONFIG_PCMCIA_SPECTRUM                          policy<{'amd64': '-'}>
+CONFIG_PCMCIA_SYM53C500                         policy<{'amd64': '-'}>
+CONFIG_PCMCIA_WL3501                            policy<{'amd64': '-'}>
+CONFIG_PCMCIA_XIRC2PS                           policy<{'amd64': '-'}>
+CONFIG_PCMCIA_XIRCOM                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCS_LYNX                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PCS_XPCS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PD6729                                   policy<{'amd64': '-'}>
+CONFIG_PDA_POWER                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PEAQ_WMI                                 policy<{'amd64': '-'}>
+CONFIG_PERF_EVENTS_AMD_UNCORE                   policy<{'amd64': 'y'}>
+CONFIG_PERF_EVENTS_INTEL_CSTATE                 policy<{'amd64': 'y'}>
+CONFIG_PERF_EVENTS_INTEL_RAPL                   policy<{'amd64': 'y'}>
+CONFIG_PERSISTENT_KEYRINGS                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PHANTOM                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PHONET                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PHYLIB                                   policy<{'amd64': 'm', 'arm64': 'y'}>
+CONFIG_PHYLINK                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PHYSICAL_ALIGN                           policy<{'amd64': '0x1000000'}>
+CONFIG_PHY_AM654_SERDES                         policy<{'arm64': '-'}>
+CONFIG_PHY_BCM_NS_USB2                          policy<{'arm64': 'n'}>
+CONFIG_PHY_BCM_NS_USB3                          policy<{'arm64': 'n'}>
+CONFIG_PHY_BCM_SR_PCIE                          policy<{'arm64': 'y'}>
+CONFIG_PHY_BCM_SR_USB                           policy<{'arm64': 'y'}>
+CONFIG_PHY_BERLIN_SATA                          policy<{'arm64': '-'}>
+CONFIG_PHY_BERLIN_USB                           policy<{'arm64': '-'}>
+CONFIG_PHY_BRCM_USB                             policy<{'arm64': '-'}>
+CONFIG_PHY_CADENCE_DPHY                         policy<{'arm64': 'n'}>
+CONFIG_PHY_CADENCE_SALVO                        policy<{'arm64': 'n'}>
+CONFIG_PHY_CADENCE_SIERRA                       policy<{'arm64': 'n'}>
+CONFIG_PHY_CADENCE_TORRENT                      policy<{'arm64': 'n'}>
+CONFIG_PHY_CAN_TRANSCEIVER                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PHY_CPCAP_USB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PHY_FSL_IMX8MQ_USB                       policy<{'arm64': 'n'}>
+CONFIG_PHY_HI3660_USB                           policy<{'arm64': '-'}>
+CONFIG_PHY_HI3670_USB                           policy<{'arm64': '-'}>
+CONFIG_PHY_HI6220_USB                           policy<{'arm64': '-'}>
+CONFIG_PHY_HISI_INNO_USB2                       policy<{'arm64': '-'}>
+CONFIG_PHY_HISTB_COMBPHY                        policy<{'arm64': '-'}>
+CONFIG_PHY_INTEL_KEEMBAY_EMMC                   policy<{'arm64': '-'}>
+CONFIG_PHY_INTEL_KEEMBAY_USB                    policy<{'arm64': '-'}>
+CONFIG_PHY_INTEL_LGM_EMMC                       policy<{'amd64': 'n'}>
+CONFIG_PHY_J721E_WIZ                            policy<{'arm64': '-'}>
+CONFIG_PHY_MAPPHONE_MDM6600                     policy<{'arm64': 'n'}>
+CONFIG_PHY_MESON8B_USB2                         policy<{'arm64': '-'}>
+CONFIG_PHY_MESON_AXG_MIPI_DPHY                  policy<{'arm64': '-'}>
+CONFIG_PHY_MESON_AXG_MIPI_PCIE_ANALOG           policy<{'arm64': '-'}>
+CONFIG_PHY_MESON_AXG_PCIE                       policy<{'arm64': '-'}>
+CONFIG_PHY_MESON_G12A_USB2                      policy<{'arm64': '-'}>
+CONFIG_PHY_MESON_G12A_USB3_PCIE                 policy<{'arm64': '-'}>
+CONFIG_PHY_MESON_GXL_USB2                       policy<{'arm64': '-'}>
+CONFIG_PHY_MIXEL_MIPI_DPHY                      policy<{'arm64': 'n'}>
+CONFIG_PHY_MTK_HDMI                             policy<{'arm64': '-'}>
+CONFIG_PHY_MTK_MIPI_DSI                         policy<{'arm64': '-'}>
+CONFIG_PHY_MTK_TPHY                             policy<{'arm64': '-'}>
+CONFIG_PHY_MTK_UFS                              policy<{'arm64': '-'}>
+CONFIG_PHY_MTK_XSPHY                            policy<{'arm64': '-'}>
+CONFIG_PHY_MVEBU_A3700_COMPHY                   policy<{'arm64': '-'}>
+CONFIG_PHY_MVEBU_A3700_UTMI                     policy<{'arm64': '-'}>
+CONFIG_PHY_MVEBU_A38X_COMPHY                    policy<{'arm64': '-'}>
+CONFIG_PHY_MVEBU_CP110_COMPHY                   policy<{'arm64': '-'}>
+CONFIG_PHY_MVEBU_CP110_UTMI                     policy<{'arm64': '-'}>
+CONFIG_PHY_NS2_USB_DRD                          policy<{'arm64': 'y'}>
+CONFIG_PHY_OCELOT_SERDES                        policy<{'arm64': 'n'}>
+CONFIG_PHY_PXA_28NM_HSIC                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PHY_PXA_28NM_USB2                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PHY_QCOM_APQ8064_SATA                    policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_IPQ4019_USB                     policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_IPQ806X_SATA                    policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_IPQ806X_USB                     policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_PCIE2                           policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_QMP                             policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_QUSB2                           policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_USB_HS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PHY_QCOM_USB_HSIC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PHY_QCOM_USB_HS_28NM                     policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_USB_SNPS_FEMTO_V2               policy<{'arm64': '-'}>
+CONFIG_PHY_QCOM_USB_SS                          policy<{'arm64': '-'}>
+CONFIG_PHY_RCAR_GEN2                            policy<{'arm64': '-'}>
+CONFIG_PHY_RCAR_GEN3_PCIE                       policy<{'arm64': '-'}>
+CONFIG_PHY_RCAR_GEN3_USB2                       policy<{'arm64': '-'}>
+CONFIG_PHY_RCAR_GEN3_USB3                       policy<{'arm64': '-'}>
+CONFIG_PHY_SAMSUNG_USB2                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PHY_SPARX5_SERDES                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PHY_SUN4I_USB                            policy<{'arm64': '-'}>
+CONFIG_PHY_SUN50I_USB3                          policy<{'arm64': '-'}>
+CONFIG_PHY_SUN6I_MIPI_DPHY                      policy<{'arm64': '-'}>
+CONFIG_PHY_SUN9I_USB                            policy<{'arm64': '-'}>
+CONFIG_PHY_TEGRA194_P2U                         policy<{'arm64': '-'}>
+CONFIG_PHY_TEGRA_XUSB                           policy<{'arm64': 'n'}>
+CONFIG_PHY_TI_GMII_SEL                          policy<{'arm64': '-'}>
+CONFIG_PHY_TUSB1210                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PHY_XILINX_ZYNQMP                        policy<{'arm64': '-'}>
+CONFIG_PI433                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCONF                                  policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_PINCTRL_ALDERLAKE                        policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_AMD                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PINCTRL_APQ8064                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_APQ8084                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_ARMADA_37XX                      policy<{'arm64': '-'}>
+CONFIG_PINCTRL_ARMADA_AP806                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_ARMADA_CP110                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_AS370                            policy<{'arm64': '-'}>
+CONFIG_PINCTRL_AS3722                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_AXP209                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_BAYTRAIL                         policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_BERLIN                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_BERLIN_BG4CT                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_BM1880                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_BROXTON                          policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_CANNONLAKE                       policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_CEDARFORK                        policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_CS47L15                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_CS47L35                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_CS47L85                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_CS47L90                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_CS47L92                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_DA9062                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_DENVERTON                        policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_ELKHARTLAKE                      policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_EMMITSBURG                       policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_GEMINILAKE                       policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_ICELAKE                          policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_IMX                              policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX8DXL                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX8MM                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX8MN                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX8MP                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX8MQ                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX8QM                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX8QXP                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX8ULP                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IMX_SCU                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_INTEL                            policy<{'amd64': '-'}>
+CONFIG_PINCTRL_IPQ4019                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IPQ6018                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IPQ8064                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_IPQ8074                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_JASPERLAKE                       policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_KEEMBAY                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_LAKEFIELD                        policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_LEWISBURG                        policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_LOCHNAGAR                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_LPASS_LPI                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_LYNXPOINT                        policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_MADERA                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_MAX77620                         policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MCP23S08                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PINCTRL_MCP23S08_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_MCP23S08_SPI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_MDM9607                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MDM9615                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MESON                            policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MESON8_PMX                       policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MESON_A1                         policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MESON_AXG                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MESON_AXG_PMX                    policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MESON_G12A                       policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MESON_GXBB                       policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MESON_GXL                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MICROCHIP_SGPIO                  policy<{'arm64': 'n'}>
+CONFIG_PINCTRL_MSM                              policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8226                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8660                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8916                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8953                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8960                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8976                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8994                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8996                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8998                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MSM8X74                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT2712                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT6397                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT6765                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT6779                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT6797                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT7622                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT8167                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT8173                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT8183                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT8192                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT8195                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT8365                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MT8516                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MTK                              policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MTK_MOORE                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MTK_PARIS                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MTK_V2                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_MVEBU                            policy<{'arm64': '-'}>
+CONFIG_PINCTRL_OCELOT                           policy<{'arm64': 'n'}>
+CONFIG_PINCTRL_OWL                              policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PALMAS                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A774A1                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A774B1                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A774C0                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A774E1                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77950                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77951                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77960                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77961                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77965                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77970                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77980                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77990                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A77995                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_PFC_R8A779A0                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_QCOM_SPMI_PMIC                   policy<{'arm64': '-'}>
+CONFIG_PINCTRL_QCOM_SSBI_PMIC                   policy<{'arm64': '-'}>
+CONFIG_PINCTRL_QCS404                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_QDF2XXX                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_RENESAS                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_RK805                            policy<{'arm64': '-'}>
+CONFIG_PINCTRL_RZG2L                            policy<{'arm64': '-'}>
+CONFIG_PINCTRL_S700                             policy<{'arm64': '-'}>
+CONFIG_PINCTRL_S900                             policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SC7180                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SC7280                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SC8180X                          policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SDM660                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SDM845                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SDX55                            policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SH_PFC                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SINGLE                           policy<{'arm64': 'n'}>
+CONFIG_PINCTRL_SM6115                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SM6125                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SM8150                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SM8250                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SM8350                           policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SPRD                             policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SPRD_SC9860                      policy<{'arm64': 'n'}>
+CONFIG_PINCTRL_STMFX                            policy<{'arm64': 'n'}>
+CONFIG_PINCTRL_SUN4I_A10                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_A100                      policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_A100_R                    policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_A64                       policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_A64_R                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_H5                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_H6                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_H616                      policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_H616_R                    policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN50I_H6_R                      policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN5I                            policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN6I_A31                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN6I_A31_R                      policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN8I_A23                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN8I_A23_R                      policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN8I_A33                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN8I_A83T                       policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN8I_A83T_R                     policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN8I_H3                         policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN8I_H3_R                       policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN8I_V3S                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN9I_A80                        policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUN9I_A80_R                      policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SUNRISEPOINT                     policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_SUNXI                            policy<{'arm64': '-'}>
+CONFIG_PINCTRL_SX150X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINCTRL_TEGRA194                         policy<{'arm64': '-'}>
+CONFIG_PINCTRL_TEGRA210                         policy<{'arm64': '-'}>
+CONFIG_PINCTRL_TIGERLAKE                        policy<{'amd64': 'n'}>
+CONFIG_PINCTRL_TMPV7700                         policy<{'arm64': '-'}>
+CONFIG_PINCTRL_VISCONTI                         policy<{'arm64': '-'}>
+CONFIG_PINCTRL_ZYNQMP                           policy<{'arm64': '-'}>
+CONFIG_PING                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PINMUX                                   policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_PKCS7_TEST_KEY                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PKCS8_PRIVATE_KEY_PARSER                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PL320_MBOX                               policy<{'arm64': 'n'}>
+CONFIG_PL330_DMA                                policy<{'arm64': 'n'}>
+CONFIG_PLATFORM_MHU                             policy<{'arm64': 'n'}>
+CONFIG_PLATFORM_SI4713                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PLAYSTATION_FF                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PLIP                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PLX_DMA                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PLX_HERMES                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PM8916_WATCHDOG                          policy<{'arm64': '-'}>
+CONFIG_PMBUS                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PMIC_ADP5520                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PMIC_DA903X                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PMIC_DA9052                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PMS7003                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PM_ADVANCED_DEBUG                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PM_DEBUG                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PM_DEVFREQ                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PM_DEVFREQ_EVENT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PM_GENERIC_DOMAINS                       policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_PM_GENERIC_DOMAINS_SLEEP                 policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_PM_NOTIFIER_ERROR_INJECT                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PM_OPP                                   policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_PM_SLEEP_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PM_STD_PARTITION                         policy<{'amd64': '-'}>
+CONFIG_PM_TEST_SUSPEND                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PM_TRACE                                 policy<{'amd64': '-'}>
+CONFIG_PM_TRACE_RTC                             policy<{'amd64': '-'}>
+CONFIG_PM_WAKELOCKS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PM_WAKELOCKS_GC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PM_WAKELOCKS_LIMIT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PNP_DEBUG_MESSAGES                       policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_POWERCAP                                 policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_POWER_CTRL_LOGIC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_POWER_RESET                              policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_POWER_RESET_AS3722                       policy<{'arm64': '-'}>
+CONFIG_POWER_RESET_ATC260X                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_POWER_RESET_GPIO                         policy<{'arm64': 'n'}>
+CONFIG_POWER_RESET_GPIO_RESTART                 policy<{'arm64': 'n'}>
+CONFIG_POWER_RESET_HISI                         policy<{'arm64': '-'}>
+CONFIG_POWER_RESET_LINKSTATION                  policy<{'arm64': '-'}>
+CONFIG_POWER_RESET_LTC2952                      policy<{'arm64': 'n'}>
+CONFIG_POWER_RESET_MSM                          policy<{'arm64': '-'}>
+CONFIG_POWER_RESET_MT6323                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_POWER_RESET_OCELOT_RESET                 policy<{'arm64': '-'}>
+CONFIG_POWER_RESET_QCOM_PON                     policy<{'arm64': '-'}>
+CONFIG_POWER_RESET_REGULATOR                    policy<{'arm64': 'n'}>
+CONFIG_POWER_RESET_RESTART                      policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_POWER_RESET_SC27XX                       policy<{'arm64': '-'}>
+CONFIG_POWER_RESET_SYSCON_POWEROFF              policy<{'arm64': 'n'}>
+CONFIG_POWER_RESET_TPS65086                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_POWER_RESET_VEXPRESS                     policy<{'arm64': 'n'}>
+CONFIG_POWER_RESET_XGENE                        policy<{'arm64': 'y'}>
+CONFIG_POWER_SUPPLY_HWMON                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PPDEV                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PPP                                      policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_PPPOATM                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PPPOL2TP                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PPS_CLIENT_GPIO                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PPS_CLIENT_LDISC                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PPS_CLIENT_PARPORT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PPTP                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PREEMPT                                  policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_PREEMPTION                               policy<{'arm64': 'y'}>
+CONFIG_PREEMPT_COUNT                            policy<{'arm64': 'y'}>
+CONFIG_PREEMPT_RCU                              policy<{'arm64': 'y'}>
+CONFIG_PREEMPT_TRACER                           policy<{'arm64': 'n'}>
+CONFIG_PREEMPT_VOLUNTARY                        policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_PRESTERA                                 policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_PRESTERA_PCI                             policy<{'amd64': '-', 'arm64': 'm'}>
+CONFIG_PRINTER                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PRISM2_USB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PROCESSOR_SELECT                         policy<{'amd64': 'n'}>
+CONFIG_PROC_CPU_RESCTRL                         policy<{'amd64': '-'}>
+CONFIG_PROC_PID_CPUSET                          policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_PROC_VMCORE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PROC_VMCORE_DEVICE_DUMP                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PRU_REMOTEPROC                           policy<{'arm64': '-'}>
+CONFIG_PSAMPLE                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PSTORE                                   policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_PSTORE_842_COMPRESS                      policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_BLK                               policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_BLK_BLKDEV                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PSTORE_BLK_KMSG_SIZE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PSTORE_BLK_MAX_REASON                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PSTORE_COMPRESS                          policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_PSTORE_COMPRESS_DEFAULT                  policy<{'amd64': '"deflate"', 'arm64': '-'}>
+CONFIG_PSTORE_CONSOLE                           policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_DEFAULT_KMSG_BYTES                policy<{'amd64': '10240', 'arm64': '-'}>
+CONFIG_PSTORE_DEFLATE_COMPRESS                  policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_PSTORE_DEFLATE_COMPRESS_DEFAULT          policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_PSTORE_FTRACE                            policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_LZ4HC_COMPRESS                    policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_LZ4_COMPRESS                      policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_LZO_COMPRESS                      policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_PMSG                              policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_RAM                               policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PSTORE_ZONE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PSTORE_ZSTD_COMPRESS                     policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PTDUMP_CORE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PTP_1588_CLOCK_DTE                       policy<{'arm64': 'y'}>
+CONFIG_PTP_1588_CLOCK_IDT82P33                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PTP_1588_CLOCK_IDTCM                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PTP_1588_CLOCK_INES                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PTP_1588_CLOCK_KVM                       policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_PTP_1588_CLOCK_OCP                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PTP_1588_CLOCK_QORIQ                     policy<{'arm64': '-'}>
+CONFIG_PTP_1588_CLOCK_VMW                       policy<{'amd64': 'n'}>
+CONFIG_PUNIT_ATOM_DEBUG                         policy<{'amd64': 'n'}>
+CONFIG_PVPANIC                                  policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_PVPANIC_MMIO                             policy<{'amd64': 'm', 'arm64': '-'}>
+CONFIG_PVPANIC_PCI                              policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_PWM                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_PWM_ATMEL_HLCDC_PWM                      policy<{'arm64': '-'}>
+CONFIG_PWM_ATMEL_TCB                            policy<{'arm64': '-'}>
+CONFIG_PWM_BCM2835                              policy<{'arm64': '-'}>
+CONFIG_PWM_BCM_IPROC                            policy<{'arm64': '-'}>
+CONFIG_PWM_BERLIN                               policy<{'arm64': '-'}>
+CONFIG_PWM_BRCMSTB                              policy<{'arm64': '-'}>
+CONFIG_PWM_CRC                                  policy<{'amd64': '-'}>
+CONFIG_PWM_CROS_EC                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_DWC                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_FSL_FTM                              policy<{'arm64': '-'}>
+CONFIG_PWM_HIBVT                                policy<{'arm64': '-'}>
+CONFIG_PWM_IMX1                                 policy<{'arm64': '-'}>
+CONFIG_PWM_IMX27                                policy<{'arm64': '-'}>
+CONFIG_PWM_IMX_TPM                              policy<{'arm64': '-'}>
+CONFIG_PWM_IQS620A                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_KEEMBAY                              policy<{'arm64': '-'}>
+CONFIG_PWM_LP3943                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_LPSS                                 policy<{'amd64': '-'}>
+CONFIG_PWM_LPSS_PCI                             policy<{'amd64': '-'}>
+CONFIG_PWM_LPSS_PLATFORM                        policy<{'amd64': '-'}>
+CONFIG_PWM_MEDIATEK                             policy<{'arm64': '-'}>
+CONFIG_PWM_MESON                                policy<{'arm64': '-'}>
+CONFIG_PWM_MTK_DISP                             policy<{'arm64': '-'}>
+CONFIG_PWM_NTXEC                                policy<{'arm64': '-'}>
+CONFIG_PWM_PCA9685                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_RASPBERRYPI_POE                      policy<{'arm64': '-'}>
+CONFIG_PWM_RCAR                                 policy<{'arm64': '-'}>
+CONFIG_PWM_RENESAS_TPU                          policy<{'arm64': '-'}>
+CONFIG_PWM_ROCKCHIP                             policy<{'arm64': '-'}>
+CONFIG_PWM_SL28CPLD                             policy<{'arm64': '-'}>
+CONFIG_PWM_SPRD                                 policy<{'arm64': '-'}>
+CONFIG_PWM_STMPE                                policy<{'arm64': '-'}>
+CONFIG_PWM_SUN4I                                policy<{'arm64': '-'}>
+CONFIG_PWM_SYSFS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_TEGRA                                policy<{'arm64': '-'}>
+CONFIG_PWM_TIECAP                               policy<{'arm64': '-'}>
+CONFIG_PWM_TIEHRPWM                             policy<{'arm64': '-'}>
+CONFIG_PWM_TWL                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_TWL_LED                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_PWM_VISCONTI                             policy<{'arm64': '-'}>
+CONFIG_PWRSEQ_SD8787                            policy<{'arm64': '-'}>
+CONFIG_PXA168_ETH                               policy<{'arm64': '-'}>
+CONFIG_QCA7000                                  policy<{'arm64': '-'}>
+CONFIG_QCA7000_SPI                              policy<{'arm64': '-'}>
+CONFIG_QCA7000_UART                             policy<{'arm64': '-'}>
+CONFIG_QCOM_A53PLL                              policy<{'arm64': '-'}>
+CONFIG_QCOM_A7PLL                               policy<{'arm64': '-'}>
+CONFIG_QCOM_AOSS_QMP                            policy<{'arm64': '-'}>
+CONFIG_QCOM_APCS_IPC                            policy<{'arm64': '-'}>
+CONFIG_QCOM_APR                                 policy<{'arm64': '-'}>
+CONFIG_QCOM_BAM_DMA                             policy<{'arm64': '-'}>
+CONFIG_QCOM_CLK_APCC_MSM8996                    policy<{'arm64': '-'}>
+CONFIG_QCOM_CLK_APCS_MSM8916                    policy<{'arm64': '-'}>
+CONFIG_QCOM_CLK_APCS_SDX55                      policy<{'arm64': '-'}>
+CONFIG_QCOM_CLK_RPM                             policy<{'arm64': '-'}>
+CONFIG_QCOM_CLK_RPMH                            policy<{'arm64': '-'}>
+CONFIG_QCOM_CLK_SMD_RPM                         policy<{'arm64': '-'}>
+CONFIG_QCOM_COINCELL                            policy<{'arm64': '-'}>
+CONFIG_QCOM_COMMAND_DB                          policy<{'arm64': '-'}>
+CONFIG_QCOM_CPR                                 policy<{'arm64': '-'}>
+CONFIG_QCOM_EBI2                                policy<{'arm64': '-'}>
+CONFIG_QCOM_EMAC                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QCOM_FASTRPC                             policy<{'arm64': '-'}>
+CONFIG_QCOM_GDSC                                policy<{'arm64': '-'}>
+CONFIG_QCOM_GENI_SE                             policy<{'arm64': '-'}>
+CONFIG_QCOM_GPI_DMA                             policy<{'arm64': '-'}>
+CONFIG_QCOM_GSBI                                policy<{'arm64': '-'}>
+CONFIG_QCOM_HFPLL                               policy<{'arm64': '-'}>
+CONFIG_QCOM_HIDMA                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QCOM_HIDMA_MGMT                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QCOM_IOMMU                               policy<{'arm64': '-'}>
+CONFIG_QCOM_IPA                                 policy<{'arm64': '-'}>
+CONFIG_QCOM_IPCC                                policy<{'arm64': '-'}>
+CONFIG_QCOM_IRQ_COMBINER                        policy<{'arm64': '-'}>
+CONFIG_QCOM_KRYO_L2_ACCESSORS                   policy<{'arm64': '-'}>
+CONFIG_QCOM_L2_PMU                              policy<{'arm64': '-'}>
+CONFIG_QCOM_L3_PMU                              policy<{'arm64': '-'}>
+CONFIG_QCOM_LLCC                                policy<{'arm64': '-'}>
+CONFIG_QCOM_LMH                                 policy<{'arm64': '-'}>
+CONFIG_QCOM_MDT_LOADER                          policy<{'arm64': '-'}>
+CONFIG_QCOM_OCMEM                               policy<{'arm64': '-'}>
+CONFIG_QCOM_PDC                                 policy<{'arm64': '-'}>
+CONFIG_QCOM_PDR_HELPERS                         policy<{'arm64': '-'}>
+CONFIG_QCOM_PIL_INFO                            policy<{'arm64': '-'}>
+CONFIG_QCOM_Q6V5_ADSP                           policy<{'arm64': '-'}>
+CONFIG_QCOM_Q6V5_COMMON                         policy<{'arm64': '-'}>
+CONFIG_QCOM_Q6V5_MSS                            policy<{'arm64': '-'}>
+CONFIG_QCOM_Q6V5_PAS                            policy<{'arm64': '-'}>
+CONFIG_QCOM_Q6V5_WCSS                           policy<{'arm64': '-'}>
+CONFIG_QCOM_QFPROM                              policy<{'arm64': '-'}>
+CONFIG_QCOM_QMI_HELPERS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QCOM_RMTFS_MEM                           policy<{'arm64': '-'}>
+CONFIG_QCOM_RPMCC                               policy<{'arm64': '-'}>
+CONFIG_QCOM_RPMH                                policy<{'arm64': '-'}>
+CONFIG_QCOM_RPMHPD                              policy<{'arm64': '-'}>
+CONFIG_QCOM_RPMPD                               policy<{'arm64': '-'}>
+CONFIG_QCOM_RPROC_COMMON                        policy<{'arm64': '-'}>
+CONFIG_QCOM_SCM                                 policy<{'arm64': '-'}>
+CONFIG_QCOM_SCM_DOWNLOAD_MODE_DEFAULT           policy<{'arm64': '-'}>
+CONFIG_QCOM_SMD_RPM                             policy<{'arm64': '-'}>
+CONFIG_QCOM_SMEM                                policy<{'arm64': '-'}>
+CONFIG_QCOM_SMEM_STATE                          policy<{'arm64': '-'}>
+CONFIG_QCOM_SMP2P                               policy<{'arm64': '-'}>
+CONFIG_QCOM_SMSM                                policy<{'arm64': '-'}>
+CONFIG_QCOM_SOCINFO                             policy<{'arm64': '-'}>
+CONFIG_QCOM_SPMI_ADC5                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QCOM_SPMI_ADC_TM5                        policy<{'arm64': '-'}>
+CONFIG_QCOM_SPMI_IADC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QCOM_SPMI_TEMP_ALARM                     policy<{'arm64': '-'}>
+CONFIG_QCOM_SPMI_VADC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QCOM_SYSMON                              policy<{'arm64': '-'}>
+CONFIG_QCOM_TSENS                               policy<{'arm64': '-'}>
+CONFIG_QCOM_VADC_COMMON                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QCOM_WCNSS_CTRL                          policy<{'arm64': '-'}>
+CONFIG_QCOM_WCNSS_PIL                           policy<{'arm64': '-'}>
+CONFIG_QCOM_WDT                                 policy<{'arm64': '-'}>
+CONFIG_QCS_GCC_404                              policy<{'arm64': '-'}>
+CONFIG_QCS_Q6SSTOP_404                          policy<{'arm64': '-'}>
+CONFIG_QCS_TURING_404                           policy<{'arm64': '-'}>
+CONFIG_QED_RDMA                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QE_TDM                                   policy<{'arm64': '-'}>
+CONFIG_QFMT_V1                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QLA3XXX                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QLCNIC                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QLCNIC_DCB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QLCNIC_HWMON                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QLCNIC_SRIOV                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QLGE                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QNX4FS_FS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QNX6FS_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QNX6FS_FS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QORIQ_CPUFREQ                            policy<{'arm64': '-'}>
+CONFIG_QORIQ_THERMAL                            policy<{'arm64': '-'}>
+CONFIG_QRTR                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QRTR_MHI                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QRTR_SMD                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QRTR_TUN                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QSEMI_PHY                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_QTNFMAC                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QTNFMAC_PCIE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_QUICC_ENGINE                             policy<{'arm64': 'n'}>
+CONFIG_R6040                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_R8188EU                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_R8712U                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_ADAPTERS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_MAXIRADIO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_SAA7706H                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_SHARK                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_SHARK2                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_SI470X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_SI4713                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_SI476X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_TEA575X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_TEA5764                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_TEF6862                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_WL1273                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RADIO_WL128X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RANDOMIZE_KSTACK_OFFSET_DEFAULT          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RAPIDIO                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RAPIDIO_CHMAN                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_CPS_GEN2                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_CPS_XX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_DISC_TIMEOUT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_DMA_ENGINE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_ENABLE_RX_TX_PORTS               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_ENUM_BASIC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_MPORT_CDEV                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_RXS_GEN3                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_TSI568                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_TSI57X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAPIDIO_TSI721                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RASPBERRYPI_FIRMWARE                     policy<{'arm64': '-'}>
+CONFIG_RASPBERRYPI_POWER                        policy<{'arm64': '-'}>
+CONFIG_RAS_CEC                                  policy<{'amd64': 'n'}>
+CONFIG_RAS_CEC_DEBUG                            policy<{'amd64': '-'}>
+CONFIG_RAVB                                     policy<{'arm64': '-'}>
+CONFIG_RAVE_SP_CORE                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RAVE_SP_EEPROM                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RAVE_SP_WATCHDOG                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RCAR_DMAC                                policy<{'arm64': '-'}>
+CONFIG_RCAR_GEN3_THERMAL                        policy<{'arm64': '-'}>
+CONFIG_RCAR_THERMAL                             policy<{'arm64': '-'}>
+CONFIG_RCU_TRACE                                policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_RC_ATI_REMOTE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RC_CORE                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RC_DECODERS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RC_DEVICES                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RC_LOOPBACK                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RC_MAP                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RC_XBOX_DVD                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RDMA_RXE                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RDMA_SIW                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RDS_RDMA                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REALTEK_AUTOPM                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REBOOT_MODE                              policy<{'arm64': '-'}>
+CONFIG_REED_SOLOMON                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REED_SOLOMON_DEC16                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REED_SOLOMON_DEC8                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REED_SOLOMON_ENC8                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP                                   policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_REGMAP_AC97                              policy<{'arm64': '-'}>
+CONFIG_REGMAP_I2C                               policy<{'amd64': '-', 'arm64': 'm'}>
+CONFIG_REGMAP_I3C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_IRQ                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_MMIO                              policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_REGMAP_SCCB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_SLIMBUS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_SOUNDWIRE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_SOUNDWIRE_MBQ                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_SPI_AVMM                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_SPMI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGMAP_W1                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_88PG86X                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_88PM800                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_88PM8607                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_AAT2870                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_ACT8865                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_ACT8945A                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_AD5398                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_ANATOP                         policy<{'arm64': '-'}>
+CONFIG_REGULATOR_ARIZONA_LDO1                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_ARIZONA_MICSUPP                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_ARM_SCMI                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_AS3711                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_AS3722                         policy<{'arm64': '-'}>
+CONFIG_REGULATOR_ATC260X                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_AXP20X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_BCM590XX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_BD71815                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_BD71828                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_BD718XX                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_BD9571MWV                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_BD957XMUF                      policy<{'arm64': '-'}>
+CONFIG_REGULATOR_CPCAP                          policy<{'arm64': '-'}>
+CONFIG_REGULATOR_CROS_EC                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_DA903X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_DA9052                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_DA9055                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_DA9062                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_DA9063                         policy<{'arm64': '-'}>
+CONFIG_REGULATOR_DA9121                         policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_DA9210                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_DA9211                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_FAN53555                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_FAN53880                       policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_GPIO                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_HI6421                         policy<{'arm64': '-'}>
+CONFIG_REGULATOR_HI6421V530                     policy<{'arm64': '-'}>
+CONFIG_REGULATOR_HI6421V600                     policy<{'arm64': '-'}>
+CONFIG_REGULATOR_HI655X                         policy<{'arm64': '-'}>
+CONFIG_REGULATOR_ISL6271A                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_ISL9305                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_LM363X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_LOCHNAGAR                      policy<{'arm64': '-'}>
+CONFIG_REGULATOR_LP3971                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_LP3972                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_LP872X                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_LP873X                         policy<{'arm64': '-'}>
+CONFIG_REGULATOR_LP8755                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_LP87565                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_LP8788                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_LTC3589                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_LTC3676                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MAX14577                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MAX1586                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MAX77620                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_MAX77650                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_MAX77686                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_MAX77693                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MAX77802                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_MAX77826                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MAX8649                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MAX8660                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MAX8893                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MAX8907                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MAX8925                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MAX8952                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MAX8973                        policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_MAX8997                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MAX8998                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MC13783                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MC13892                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MC13XXX_CORE                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MCP16502                       policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_MP5416                         policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_MP8859                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MP886X                         policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_MPQ7920                        policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_MT6311                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_MT6315                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MT6323                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MT6358                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MT6359                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MT6360                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_MT6380                         policy<{'arm64': '-'}>
+CONFIG_REGULATOR_MT6397                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_PALMAS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_PCA9450                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_PCAP                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_PCF50633                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_PF8X00                         policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_PFUZE100                       policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_PV88060                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_PV88080                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_PV88090                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_PWM                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_QCOM_LABIBB                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_QCOM_RPM                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_QCOM_RPMH                      policy<{'arm64': '-'}>
+CONFIG_REGULATOR_QCOM_SMD_RPM                   policy<{'arm64': '-'}>
+CONFIG_REGULATOR_QCOM_SPMI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_QCOM_USB_VBUS                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_RASPBERRYPI_TOUCHSCREEN_ATTINY policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_REGULATOR_RC5T583                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_RK808                          policy<{'arm64': '-'}>
+CONFIG_REGULATOR_RN5T618                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_ROHM                           policy<{'arm64': '-'}>
+CONFIG_REGULATOR_RT4801                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_RT4831                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_RT5033                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_RT6160                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_RT6245                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_RTMV20                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_RTQ2134                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_RTQ6752                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_S2MPA01                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_S2MPS11                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_S5M8767                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_SC2731                         policy<{'arm64': '-'}>
+CONFIG_REGULATOR_SKY81452                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_SLG51000                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_STPMIC1                        policy<{'arm64': '-'}>
+CONFIG_REGULATOR_SY8106A                        policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_SY8824X                        policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_SY8827N                        policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_TPS51632                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_TPS6105X                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_TPS62360                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_TPS65023                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_TPS6507X                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_TPS65086                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_TPS65090                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_TPS65132                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_TPS65218                       policy<{'arm64': '-'}>
+CONFIG_REGULATOR_TPS6524X                       policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_REGULATOR_TPS6586X                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_TPS65910                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_TPS65912                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_TPS80031                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_USERSPACE_CONSUMER             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_VCTRL                          policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_VEXPRESS                       policy<{'arm64': 'n'}>
+CONFIG_REGULATOR_VIRTUAL_CONSUMER               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REGULATOR_VQMMC_IPQ4019                  policy<{'arm64': '-'}>
+CONFIG_REGULATOR_WM831X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_WM8350                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_WM8400                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REGULATOR_WM8994                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REISERFS_CHECK                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REISERFS_FS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REISERFS_FS_POSIX_ACL                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REISERFS_FS_SECURITY                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REISERFS_FS_XATTR                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REISERFS_PROC_INFO                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_REMOTEPROC                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_REMOTEPROC_CDEV                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RENESAS_DMA                              policy<{'arm64': '-'}>
+CONFIG_RENESAS_IRQC                             policy<{'arm64': '-'}>
+CONFIG_RENESAS_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RENESAS_RPCIF                            policy<{'arm64': '-'}>
+CONFIG_RENESAS_RZAWDT                           policy<{'arm64': '-'}>
+CONFIG_RENESAS_USB_DMAC                         policy<{'arm64': '-'}>
+CONFIG_RENESAS_WDT                              policy<{'arm64': '-'}>
+CONFIG_RESET_A10SR                              policy<{'arm64': '-'}>
+CONFIG_RESET_ATTACK_MITIGATION                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RESET_BERLIN                             policy<{'arm64': '-'}>
+CONFIG_RESET_BRCMSTB                            policy<{'arm64': '-'}>
+CONFIG_RESET_BRCMSTB_RESCAL                     policy<{'arm64': '-'}>
+CONFIG_RESET_CONTROLLER                         policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_RESET_HISI                               policy<{'arm64': '-'}>
+CONFIG_RESET_IMX7                               policy<{'arm64': '-'}>
+CONFIG_RESET_MCHP_SPARX5                        policy<{'arm64': '-'}>
+CONFIG_RESET_MESON                              policy<{'arm64': '-'}>
+CONFIG_RESET_MESON_AUDIO_ARB                    policy<{'arm64': '-'}>
+CONFIG_RESET_QCOM_AOSS                          policy<{'arm64': '-'}>
+CONFIG_RESET_QCOM_PDC                           policy<{'arm64': '-'}>
+CONFIG_RESET_RASPBERRYPI                        policy<{'arm64': '-'}>
+CONFIG_RESET_RZG2L_USBPHY_CTRL                  policy<{'arm64': '-'}>
+CONFIG_RESET_SCMI                               policy<{'arm64': '-'}>
+CONFIG_RESET_SUNXI                              policy<{'arm64': '-'}>
+CONFIG_RESET_TEGRA_BPMP                         policy<{'arm64': '-'}>
+CONFIG_RESET_TI_SCI                             policy<{'arm64': '-'}>
+CONFIG_RESET_TI_SYSCON                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RETU_WATCHDOG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RFD77402                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RFD_FTL                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RFKILL                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RFKILL_GPIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RFKILL_INPUT                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RFKILL_LEDS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RIONET                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RIONET_RX_SIZE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RIONET_TX_SIZE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_2D_SENSOR                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_CORE                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RMI4_F03                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_F03_SERIO                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_F11                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_F12                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_F30                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_F34                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_F3A                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_F54                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_F55                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_I2C                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_SMB                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMI4_SPI                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RMNET                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RN5T618_ADC                              policy<{'arm64': '-'}>
+CONFIG_RN5T618_POWER                            policy<{'arm64': '-'}>
+CONFIG_RN5T618_WATCHDOG                         policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_ANALOGIX_DP                     policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_CDN_DP                          policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_DW_HDMI                         policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_DW_MIPI_DSI                     policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_INNO_HDMI                       policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_IOMMU                           policy<{'arm64': 'n'}>
+CONFIG_ROCKCHIP_LVDS                            policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_PHY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ROCKCHIP_RGB                             policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_RK3066_HDMI                     policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_SARADC                          policy<{'arm64': '-'}>
+CONFIG_ROCKCHIP_THERMAL                         policy<{'arm64': 'y'}>
+CONFIG_ROCKER                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ROMFS_BACKED_BY_BLOCK                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ROMFS_BACKED_BY_BOTH                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ROMFS_BACKED_BY_MTD                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ROMFS_FS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ROMFS_ON_BLOCK                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ROSE                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RPMSG                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RPMSG_CHAR                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RPMSG_MTK_SCP                            policy<{'arm64': '-'}>
+CONFIG_RPMSG_NS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RPMSG_QCOM_GLINK                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RPMSG_QCOM_GLINK_RPM                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RPMSG_QCOM_GLINK_SMEM                    policy<{'arm64': '-'}>
+CONFIG_RPMSG_QCOM_SMD                           policy<{'arm64': '-'}>
+CONFIG_RPMSG_VIRTIO                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RPMSG_WWAN_CTRL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RPR0521                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RSI_91X                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RSI_COEX                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RSI_DEBUGFS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RSI_SDIO                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RSI_USB                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RST_RCAR                                 policy<{'arm64': '-'}>
+CONFIG_RT2400PCI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2500PCI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2500USB                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800PCI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800PCI_RT3290                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800PCI_RT33XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800PCI_RT35XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800PCI_RT53XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800USB                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800USB_RT33XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800USB_RT3573                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800USB_RT35XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800USB_RT53XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800USB_RT55XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800USB_UNKNOWN                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800_LIB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2800_LIB_MMIO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_DEBUG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_LIB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_LIB_CRYPTO                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_LIB_DEBUGFS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_LIB_FIRMWARE                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_LIB_LEDS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_LIB_MMIO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_LIB_PCI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT2X00_LIB_USB                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT61PCI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RT73USB                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_88PM80X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_88PM860X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_ABB5ZES3                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_ABEOZ9                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_ABX80X                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_ARMADA38X                        policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_AS3722                           policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_BD70528                          policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_BQ32K                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_BQ4802                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_BRCMSTB                          policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_CADENCE                          policy<{'arm64': 'n'}>
+CONFIG_RTC_DRV_CPCAP                            policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_CROS_EC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DA9052                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DA9055                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DA9063                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DS1286                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1302                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1305                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1307                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1307_CENTURY                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DS1343                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1347                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1374                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1374_WDT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DS1390                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1511                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1553                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1672                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1685                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DS1685_FAMILY                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS1689                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DS17285                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DS1742                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS17485                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DS17885                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_DS2404                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS3232                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_DS3232_HWMON                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_EM3027                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_FM3130                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_FSL_FTM_ALARM                    policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_FTRTC010                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_GOLDFISH                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_HID_SENSOR_TIME                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_HYM8563                          policy<{'arm64': 'n'}>
+CONFIG_RTC_DRV_IMXDI                            policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_IMX_SC                           policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_ISL12022                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_ISL12026                         policy<{'arm64': 'n'}>
+CONFIG_RTC_DRV_ISL1208                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_LP8788                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_M41T80                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_M41T80_WDT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_M41T93                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_M41T94                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_M48T35                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_M48T59                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_M48T86                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_MAX6900                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_MAX6902                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_MAX6916                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_MAX77686                         policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_MAX8907                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_MAX8925                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_MAX8997                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_MAX8998                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_MC13XXX                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_MCP795                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_MESON_VRTC                       policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_MSM6242                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_MT2712                           policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_MT6397                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_MT7622                           policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_MV                               policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_MXC                              policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_MXC_V2                           policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_NTXEC                            policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_PALMAS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_PCAP                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_PCF2123                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_PCF2127                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_PCF50633                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_PCF85063                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_PCF8523                          policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_RTC_DRV_PCF85263                         policy<{'amd64': '-'}>
+CONFIG_RTC_DRV_PCF85363                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_PCF8563                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_PCF8583                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_PL030                            policy<{'arm64': 'n'}>
+CONFIG_RTC_DRV_PL031                            policy<{'arm64': 'n'}>
+CONFIG_RTC_DRV_PM8XXX                           policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_R7301                            policy<{'arm64': 'n'}>
+CONFIG_RTC_DRV_R9701                            policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RC5T583                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_RC5T619                          policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_RK808                            policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_RP5C01                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RS5C348                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RS5C372                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RTD119X                          policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_RV3028                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RV3029C2                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RV3029_HWMON                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_RV3032                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RV8803                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RX4581                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RX6110                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RX8010                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RX8025                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_RX8581                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_S35390A                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_S5M                              policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_SC27XX                           policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_SD3078                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_SH                               policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_SNVS                             policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_STK17TA8                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_SUN6I                            policy<{'arm64': '-'}>
+CONFIG_RTC_DRV_TEGRA                            policy<{'arm64': 'n'}>
+CONFIG_RTC_DRV_TPS6586X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_TPS65910                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_TPS80031                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_V3020                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_WILCO_EC                         policy<{'amd64': '-'}>
+CONFIG_RTC_DRV_WM831X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_WM8350                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTC_DRV_X1205                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_RTC_DRV_ZYNQMP                           policy<{'arm64': 'n'}>
+CONFIG_RTC_I2C_AND_SPI                          policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_RTD119X_WATCHDOG                         policy<{'arm64': '-'}>
+CONFIG_RTL8180                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8187                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8187_LEDS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8188EE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8192CE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8192CU                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8192C_COMMON                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8192DE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8192E                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8192EE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8192SE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8192U                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8723AE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8723BE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8723BS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8723_COMMON                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8821AE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8XXXU                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL8XXXU_UNTESTED                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLBTCOEXIST                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLLIB                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLLIB_CRYPTO_CCMP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLLIB_CRYPTO_TKIP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLLIB_CRYPTO_WEP                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLWIFI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLWIFI_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLWIFI_PCI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTLWIFI_USB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTL_CARDS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTS5208                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_8723D                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_8723DE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_8821C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_8821CE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_8822B                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_8822BE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_8822C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_8822CE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_CORE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_DEBUG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_DEBUGFS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW88_PCI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW89                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW89_8852AE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW89_CORE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW89_DEBUG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW89_DEBUGFS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW89_DEBUGMSG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RTW89_PCI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RXKAD                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_RZG2L_ADC                                policy<{'arm64': '-'}>
+CONFIG_RZ_DMAC                                  policy<{'arm64': '-'}>
+CONFIG_SAMPLES                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SAMPLE_AUXDISPLAY                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_CONFIGFS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_FTRACE_DIRECT                     policy<{'amd64': '-'}>
+CONFIG_SAMPLE_HW_BREAKPOINT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_KDB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_KFIFO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_KOBJECT                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_KPROBES                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_LIVEPATCH                         policy<{'amd64': '-'}>
+CONFIG_SAMPLE_QMI_CLIENT                        policy<{'arm64': '-'}>
+CONFIG_SAMPLE_RPMSG_CLIENT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_TRACE_ARRAY                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_TRACE_EVENTS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_VFIO_MDEV_MBOCHS                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_VFIO_MDEV_MDPY                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_VFIO_MDEV_MDPY_FB                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_VFIO_MDEV_MTTY                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMPLE_WATCHDOG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SAMSUNG_LAPTOP                           policy<{'amd64': '-'}>
+CONFIG_SAMSUNG_Q10                              policy<{'amd64': 'n'}>
+CONFIG_SATA_ACARD_AHCI                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SATA_AHCI_SEATTLE                        policy<{'arm64': 'n'}>
+CONFIG_SATA_DWC                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SATA_DWC_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SATA_DWC_OLD_DMA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SATA_INIC162X                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SATA_MOBILE_LPM_POLICY                   policy<{'amd64': '0', 'arm64': '0'}>
+CONFIG_SATA_RCAR                                policy<{'arm64': '-'}>
+CONFIG_SATA_ULI                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SATA_ZPODD                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SBC_EPX_C3_WATCHDOG                      policy<{'amd64': 'n'}>
+CONFIG_SBC_FITPC2_WATCHDOG                      policy<{'amd64': 'n'}>
+CONFIG_SBP_TARGET                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SC1200_WDT                               policy<{'amd64': 'n'}>
+CONFIG_SC27XX_ADC                               policy<{'arm64': '-'}>
+CONFIG_SC27XX_EFUSE                             policy<{'arm64': '-'}>
+CONFIG_SC92031                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCA3000                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCA3300                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCD30_CORE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCD30_I2C                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCD30_SERIAL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCHED_CORE                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCHED_MC                                 policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_SCHED_TRACER                             policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_SCR24X                                   policy<{'amd64': '-'}>
+CONFIG_SCSI_ACARD                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_ADVANSYS                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_AHA1740                             policy<{'amd64': '-'}>
+CONFIG_SCSI_AIC7XXX                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_AIC94XX                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_AM53C974                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_BFA_FC                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_BNX2_ISCSI                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_CHELSIO_FCOE                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_CXGB3_ISCSI                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_CXGB4_ISCSI                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_DC395x                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_DEBUG                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_DH_HP_SW                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_DMX3191D                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_DPT_I2O                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_EFCT                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_ESAS2R                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_FDOMAIN                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_FDOMAIN_PCI                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_FLASHPOINT                          policy<{'amd64': 'n'}>
+CONFIG_SCSI_HISI_SAS                            policy<{'arm64': 'n'}>
+CONFIG_SCSI_HISI_SAS_DEBUGFS_DEFAULT_ENABLE     policy<{'arm64': '-'}>
+CONFIG_SCSI_HISI_SAS_PCI                        policy<{'arm64': '-'}>
+CONFIG_SCSI_HPTIOP                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_IMM                                 policy<{'amd64': '-'}>
+CONFIG_SCSI_INIA100                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_INITIO                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_IPR                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_IPS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_IZIP_EPP16                          policy<{'amd64': '-'}>
+CONFIG_SCSI_IZIP_SLOW_CTR                       policy<{'amd64': '-'}>
+CONFIG_SCSI_LOWLEVEL_PCMCIA                     policy<{'amd64': '-'}>
+CONFIG_SCSI_MPI3MR                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_MVSAS_TASKLET                       policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_SCSI_MVUMI                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_MYRB                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_MYRS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_PM8001                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_PMCRAID                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_PPA                                 policy<{'amd64': '-'}>
+CONFIG_SCSI_PROC_FS                             policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_SCSI_QLOGIC_1280                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_SIM710                              policy<{'amd64': '-'}>
+CONFIG_SCSI_SNIC                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_SNIC_DEBUG_FS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_STEX                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_UFSHCD                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCSI_UFSHCD_PCI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_UFSHCD_PLATFORM                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_UFS_BSG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_UFS_CDNS_PLATFORM                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_UFS_CRYPTO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_UFS_DWC_TC_PCI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_UFS_DWC_TC_PLATFORM                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_UFS_HISI                            policy<{'arm64': '-'}>
+CONFIG_SCSI_UFS_HPB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SCSI_UFS_MEDIATEK                        policy<{'arm64': '-'}>
+CONFIG_SCSI_UFS_QCOM                            policy<{'arm64': '-'}>
+CONFIG_SCSI_UFS_TI_J721E                        policy<{'arm64': '-'}>
+CONFIG_SCSI_WD719X                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SCTP_DEFAULT_COOKIE_HMAC_MD5             policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_SCTP_DEFAULT_COOKIE_HMAC_SHA1            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SC_CAMCC_7180                            policy<{'arm64': '-'}>
+CONFIG_SC_DISPCC_7180                           policy<{'arm64': '-'}>
+CONFIG_SC_DISPCC_7280                           policy<{'arm64': '-'}>
+CONFIG_SC_GCC_7180                              policy<{'arm64': '-'}>
+CONFIG_SC_GCC_7280                              policy<{'arm64': '-'}>
+CONFIG_SC_GCC_8180X                             policy<{'arm64': '-'}>
+CONFIG_SC_GPUCC_7180                            policy<{'arm64': '-'}>
+CONFIG_SC_GPUCC_7280                            policy<{'arm64': '-'}>
+CONFIG_SC_LPASS_CORECC_7180                     policy<{'arm64': '-'}>
+CONFIG_SC_MSS_7180                              policy<{'arm64': '-'}>
+CONFIG_SC_VIDEOCC_7180                          policy<{'arm64': '-'}>
+CONFIG_SC_VIDEOCC_7280                          policy<{'arm64': '-'}>
+CONFIG_SDIO_UART                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SDMA_VERBOSITY                           policy<{'amd64': '-'}>
+CONFIG_SDM_CAMCC_845                            policy<{'arm64': '-'}>
+CONFIG_SDM_DISPCC_845                           policy<{'arm64': '-'}>
+CONFIG_SDM_GCC_660                              policy<{'arm64': '-'}>
+CONFIG_SDM_GCC_845                              policy<{'arm64': '-'}>
+CONFIG_SDM_GPUCC_660                            policy<{'arm64': '-'}>
+CONFIG_SDM_GPUCC_845                            policy<{'arm64': '-'}>
+CONFIG_SDM_LPASSCC_845                          policy<{'arm64': '-'}>
+CONFIG_SDM_MMCC_660                             policy<{'arm64': '-'}>
+CONFIG_SDM_VIDEOCC_845                          policy<{'arm64': '-'}>
+CONFIG_SDR_MAX2175                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SDR_PLATFORM_DRIVERS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SDX_GCC_55                               policy<{'arm64': '-'}>
+CONFIG_SD_ADC_MODULATOR                         policy<{'arm64': '-'}>
+CONFIG_SECONDARY_TRUSTED_KEYRING                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SECURITY_APPARMOR                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SECURITY_APPARMOR_DEBUG                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_APPARMOR_HASH                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_APPARMOR_HASH_DEFAULT           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_DMESG_RESTRICT                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SECURITY_INFINIBAND                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_LANDLOCK                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SECURITY_PATH                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SECURITY_SELINUX_CHECKREQPROT_VALUE      policy<{'amd64': '0', 'arm64': '0'}>
+CONFIG_SECURITY_SMACK                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SECURITY_SMACK_APPEND_SIGNALS            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_SMACK_BRINGUP                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_SMACK_NETFILTER                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_TOMOYO                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SECURITY_TOMOYO_ACTIVATION_TRIGGER       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_TOMOYO_INSECURE_BUILTIN_SETTING policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_TOMOYO_MAX_ACCEPT_ENTRY         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_TOMOYO_MAX_AUDIT_LOG            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_TOMOYO_OMIT_USERSPACE_LOADER    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_TOMOYO_POLICY_LOADER            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SECURITY_YAMA                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSIRION_SGP30                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSIRION_SGP40                          policy<{'amd64': '-', 'arm64': '-'}>
 CONFIG_SENSORS_AAEON                            policy<{'amd64': '-'}>
+CONFIG_SENSORS_ABITUGURU                        policy<{'amd64': 'n'}>
+CONFIG_SENSORS_ABITUGURU3                       policy<{'amd64': 'n'}>
+CONFIG_SENSORS_ACPI_POWER                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_AD7314                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SENSORS_AD7414                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_AD7418                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADC128D818                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADCXX                            policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SENSORS_ADM1021                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADM1025                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADM1026                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADM1029                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADM1031                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADM1177                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADM1266                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_ADM1275                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_ADM9240                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADS7828                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADS7871                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SENSORS_ADT7310                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SENSORS_ADT7410                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADT7411                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADT7462                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADT7470                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADT7475                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ADT7X10                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_AHT10                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_AMC6821                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_APDS990X                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_APPLESMC                         policy<{'amd64': 'n'}>
+CONFIG_SENSORS_AQUACOMPUTER_D5NEXT              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ARM_SCMI                         policy<{'arm64': '-'}>
+CONFIG_SENSORS_ARM_SCPI                         policy<{'arm64': '-'}>
+CONFIG_SENSORS_AS370                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ASB100                           policy<{'amd64': 'n'}>
+CONFIG_SENSORS_ASC7621                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ASPEED                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_ATK0110                          policy<{'amd64': 'n'}>
+CONFIG_SENSORS_ATXP1                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_AXI_FAN_CONTROL                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_BEL_PFE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_BH1770                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_BPA_RS600                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_CORSAIR_CPRO                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_CORSAIR_PSU                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_DA9052_ADC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_DA9055                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_DELL_SMM                         policy<{'amd64': 'n'}>
+CONFIG_SENSORS_DME1737                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_DPS920AB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_DRIVETEMP                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_DS1621                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_DS620                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_EMC1403                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_EMC2103                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_EMC6W201                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_F71805F                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_F71882FG                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_F75375S                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_FSCHMD                           policy<{'amd64': 'n'}>
+CONFIG_SENSORS_FSP_3Y                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_FTSTEUTATES                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_G760A                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_G762                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_GL518SM                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_GL520SM                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_GPIO_FAN                         policy<{'arm64': 'n'}>
+CONFIG_SENSORS_GSC                              policy<{'arm64': '-'}>
+CONFIG_SENSORS_HDAPS                            policy<{'amd64': 'n'}>
+CONFIG_SENSORS_HIH6130                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_HMC5843                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_HMC5843_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_HMC5843_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_I5K_AMB                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_IBMAEM                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_IBMPEX                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_IBM_CFFPS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_IIO_HWMON                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_INA209                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_INA2XX                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_INA3221                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_INSPUR_IPSPS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_INTEL_M10_BMC_HWMON              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_IR35221                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_IR36021                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_IR38064                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_IRPS5401                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_ISL29018                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_ISL29028                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_ISL68137                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_IT87                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_JC42                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LINEAGE                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LIS3LV02D                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_LIS3_I2C                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM25066                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_LM3533                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_LM63                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM70                             policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SENSORS_LM73                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM75                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM77                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM78                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM80                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM83                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM85                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM87                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM90                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM92                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM93                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM95234                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM95241                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LM95245                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LOCHNAGAR                        policy<{'arm64': '-'}>
+CONFIG_SENSORS_LTC2945                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC2947                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_LTC2947_I2C                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC2947_SPI                      policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC2978                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_LTC2978_REGULATOR                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_LTC2990                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC2992                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC3815                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_LTC4151                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC4215                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC4222                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC4245                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC4260                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_LTC4261                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX1111                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX127                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX15301                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MAX16064                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MAX16065                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX1619                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX16601                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MAX1668                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX197                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX20730                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MAX20751                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MAX31722                         policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX31730                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX31785                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MAX31790                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX34440                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MAX6621                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX6639                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX6642                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX6650                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX6697                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MAX8688                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MC13783_ADC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MCP3021                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_MENF21BMC_HWMON                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MLXREG_FAN                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MP2888                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MP2975                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_MR75203                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_NCT6683                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_NCT6775                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_NCT7802                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_NCT7904                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_NPCM7XX                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_NTC_THERMISTOR                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_NZXT_KRAKEN2                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_OCC_P9_SBE                       policy<{'arm64': '-'}>
+CONFIG_SENSORS_PC87360                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_PC87427                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_PCF8591                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_PIM4328                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_PM6764TR                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_PMBUS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_POWR1220                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_PWM_FAN                          policy<{'arm64': '-'}>
+CONFIG_SENSORS_PXE1610                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_Q54SJ108A2                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_RASPBERRYPI_HWMON                policy<{'arm64': '-'}>
+CONFIG_SENSORS_RM3100                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_RM3100_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_RM3100_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_SBRMI                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SBTSI                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SCH5627                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SCH5636                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SCH56XX_COMMON                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_SHT15                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SHT21                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SHT3x                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SHT4x                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SHTC1                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SIS5595                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SL28CPLD                         policy<{'arm64': '-'}>
+CONFIG_SENSORS_SMM665                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SMSC47B397                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SMSC47M1                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SMSC47M192                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_SPARX5                           policy<{'arm64': '-'}>
+CONFIG_SENSORS_STPDDC60                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_STTS751                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TC654                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TC74                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_THMC50                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TMP102                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TMP103                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TMP108                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TMP401                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TMP421                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TMP513                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TPS23861                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TPS40422                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_TPS53679                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_TSL2550                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_TSL2563                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_UCD9000                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_UCD9200                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_VEXPRESS                         policy<{'arm64': 'n'}>
+CONFIG_SENSORS_VIA686A                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_VIA_CPUTEMP                      policy<{'amd64': 'n'}>
+CONFIG_SENSORS_VT1211                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_VT8231                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83627EHF                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83627HF                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83773G                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83781D                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83791D                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83792D                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83793                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83795                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83795_FANCTRL                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_W83L785TS                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_W83L786NG                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SENSORS_WM831X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_WM8350                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_XDPE122                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SENSORS_XGENE                            policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_SENSORS_ZL6100                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_8250_16550A_VARIANTS              policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_SERIAL_8250_BCM7271                      policy<{'arm64': '-'}>
+CONFIG_SERIAL_8250_CS                           policy<{'amd64': '-'}>
+CONFIG_SERIAL_8250_DEPRECATED_OPTIONS           policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_SERIAL_8250_DW                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_8250_DWLIB                        policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_SERIAL_8250_EXAR                         policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_SERIAL_8250_FINTEK                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_8250_LPSS                         policy<{'amd64': 'y'}>
+CONFIG_SERIAL_8250_MEN_MCB                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_8250_MT6577                       policy<{'arm64': '-'}>
+CONFIG_SERIAL_8250_NR_UARTS                     policy<{'amd64': '32', 'arm64': '32'}>
+CONFIG_SERIAL_8250_OMAP                         policy<{'arm64': '-'}>
+CONFIG_SERIAL_8250_OMAP_TTYO_FIXUP              policy<{'arm64': '-'}>
+CONFIG_SERIAL_8250_RT288X                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_8250_RUNTIME_UARTS                policy<{'amd64': '4', 'arm64': '4'}>
+CONFIG_SERIAL_ALTERA_JTAGUART                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_ALTERA_UART                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_ALTERA_UART_BAUDRATE              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_ALTERA_UART_MAXPORTS              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_AMBA_PL010                        policy<{'arm64': 'n'}>
+CONFIG_SERIAL_ARC                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_ARC_NR_PORTS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_BCM63XX                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_CONEXANT_DIGICOLOR                policy<{'arm64': 'n'}>
+CONFIG_SERIAL_EARLYCON_ARM_SEMIHOST             policy<{'arm64': 'n'}>
+CONFIG_SERIAL_FSL_LINFLEXUART                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_FSL_LPUART                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_IMX                               policy<{'arm64': '-'}>
+CONFIG_SERIAL_IMX_CONSOLE                       policy<{'arm64': '-'}>
+CONFIG_SERIAL_IMX_EARLYCON                      policy<{'arm64': '-'}>
+CONFIG_SERIAL_IPOCTAL                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_JSM                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_KGDB_NMI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_LANTIQ                            policy<{'amd64': 'n'}>
+CONFIG_SERIAL_LITEUART                          policy<{'arm64': '-'}>
+CONFIG_SERIAL_LITEUART_MAX_PORTS                policy<{'arm64': '-'}>
+CONFIG_SERIAL_MAX3100                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SERIAL_MAX310X                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SERIAL_MEN_Z135                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_MESON                             policy<{'arm64': '-'}>
+CONFIG_SERIAL_MESON_CONSOLE                     policy<{'arm64': '-'}>
+CONFIG_SERIAL_MSM                               policy<{'arm64': '-'}>
+CONFIG_SERIAL_MSM_CONSOLE                       policy<{'arm64': '-'}>
+CONFIG_SERIAL_MVEBU_CONSOLE                     policy<{'arm64': '-'}>
+CONFIG_SERIAL_MVEBU_UART                        policy<{'arm64': '-'}>
+CONFIG_SERIAL_NONSTANDARD                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_OWL                               policy<{'arm64': '-'}>
+CONFIG_SERIAL_OWL_CONSOLE                       policy<{'arm64': '-'}>
+CONFIG_SERIAL_QCOM_GENI                         policy<{'arm64': '-'}>
+CONFIG_SERIAL_QCOM_GENI_CONSOLE                 policy<{'arm64': '-'}>
+CONFIG_SERIAL_QE                                policy<{'arm64': '-'}>
+CONFIG_SERIAL_RP2                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_RP2_NR_UARTS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_SAMSUNG                           policy<{'arm64': '-'}>
+CONFIG_SERIAL_SAMSUNG_UARTS                     policy<{'arm64': '-'}>
+CONFIG_SERIAL_SAMSUNG_UARTS_4                   policy<{'arm64': '-'}>
+CONFIG_SERIAL_SC16IS7XX                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_SC16IS7XX_CORE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_SC16IS7XX_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_SC16IS7XX_SPI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_SCCNXP                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_SCCNXP_CONSOLE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_SH_SCI_DMA                        policy<{'arm64': '-'}>
+CONFIG_SERIAL_SH_SCI_NR_UARTS                   policy<{'arm64': '-'}>
+CONFIG_SERIAL_SIFIVE                            policy<{'arm64': 'n'}>
+CONFIG_SERIAL_SPRD                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_TEGRA                             policy<{'arm64': '-'}>
+CONFIG_SERIAL_TEGRA_TCU                         policy<{'arm64': '-'}>
+CONFIG_SERIAL_TEGRA_TCU_CONSOLE                 policy<{'arm64': '-'}>
+CONFIG_SERIAL_UARTLITE                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIAL_UARTLITE_NR_UARTS                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIAL_XILINX_PS_UART                    policy<{'arm64': 'y'}>
+CONFIG_SERIAL_XILINX_PS_UART_CONSOLE            policy<{'arm64': 'y'}>
+CONFIG_SERIO_ALTERA_PS2                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIO_AMBAKMI                            policy<{'arm64': 'y'}>
+CONFIG_SERIO_APBPS2                             policy<{'arm64': 'n'}>
+CONFIG_SERIO_ARC_PS2                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIO_CT82C710                           policy<{'amd64': 'n'}>
+CONFIG_SERIO_GPIO_PS2                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIO_NVEC_PS2                           policy<{'arm64': '-'}>
+CONFIG_SERIO_PARKBD                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SERIO_PCIPS2                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIO_PS2MULT                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIO_RAW                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIO_SERPORT                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SERIO_SUN4I_PS2                          policy<{'arm64': '-'}>
+CONFIG_SFC_FALCON                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SFC_FALCON_MTD                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SFP                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SF_PDMA                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SGETMASK_SYSCALL                         policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_SGI_GRU                                  policy<{'amd64': '-'}>
+CONFIG_SGI_GRU_DEBUG                            policy<{'amd64': '-'}>
+CONFIG_SGI_PARTITION                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SGI_XP                                   policy<{'amd64': '-'}>
+CONFIG_SG_SPLIT                                 policy<{'arm64': '-'}>
+CONFIG_SH_ETH                                   policy<{'arm64': '-'}>
+CONFIG_SH_TIMER_CMT                             policy<{'arm64': '-'}>
+CONFIG_SH_TIMER_TMU                             policy<{'arm64': '-'}>
+CONFIG_SI1133                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SI1145                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SI7005                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SI7020                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SIGNATURE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SIOX                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SIOX_BUS_GPIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SIS190                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SIS900                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SKFP                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SKGE_GENESIS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SL28CPLD_WATCHDOG                        policy<{'arm64': '-'}>
+CONFIG_SLHC                                     policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_SLICOSS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SLIC_DS26522                             policy<{'arm64': '-'}>
+CONFIG_SLIMBUS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SLIM_QCOM_CTRL                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SLIM_QCOM_NGD_CTRL                       policy<{'arm64': '-'}>
+CONFIG_SLIP                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SLIP_COMPRESSED                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SLIP_MODE_SLIP6                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SLIP_SMART                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SLS                                      policy<{'amd64': 'n'}>
+CONFIG_SMARTJOYPLUS_FF                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMB_SERVER                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SMB_SERVER_CHECK_CAP_NET_ADMIN           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMB_SERVER_KERBEROS5                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMB_SERVER_SMBDIRECT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMC91X                                   policy<{'arm64': '-'}>
+CONFIG_SMSC37B787_WDT                           policy<{'amd64': 'n'}>
+CONFIG_SMSC911X                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMSC9420                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMSC_PHY                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SMSC_SCH311X_WDT                         policy<{'amd64': 'n'}>
+CONFIG_SMS_SDIO_DRV                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMS_SIANO_DEBUGFS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMS_SIANO_MDTV                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMS_SIANO_RC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SMS_USB_DRV                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SM_CAMCC_8250                            policy<{'arm64': '-'}>
+CONFIG_SM_DISPCC_8250                           policy<{'arm64': '-'}>
+CONFIG_SM_FTL                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SM_GCC_6115                              policy<{'arm64': '-'}>
+CONFIG_SM_GCC_6125                              policy<{'arm64': '-'}>
+CONFIG_SM_GCC_6350                              policy<{'arm64': '-'}>
+CONFIG_SM_GCC_8150                              policy<{'arm64': '-'}>
+CONFIG_SM_GCC_8250                              policy<{'arm64': '-'}>
+CONFIG_SM_GCC_8350                              policy<{'arm64': '-'}>
+CONFIG_SM_GPUCC_8150                            policy<{'arm64': '-'}>
+CONFIG_SM_GPUCC_8250                            policy<{'arm64': '-'}>
+CONFIG_SM_VIDEOCC_8150                          policy<{'arm64': '-'}>
+CONFIG_SM_VIDEOCC_8250                          policy<{'arm64': '-'}>
+CONFIG_SND_AC97_CODEC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_AC97_POWER_SAVE                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_AC97_POWER_SAVE_DEFAULT              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_AD1889                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ALI5451                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ALOOP                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ALS300                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ALS4000                              policy<{'amd64': '-'}>
+CONFIG_SND_ASIHPI                               policy<{'amd64': '-'}>
+CONFIG_SND_ATIIXP                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ATIIXP_MODEM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ATMEL_SOC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_AU8810                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_AU8820                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_AU8830                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_AUDIO_GRAPH_CARD                     policy<{'arm64': '-'}>
+CONFIG_SND_AW2                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_AZT3328                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_BCD2000                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_BCM2835                              policy<{'arm64': '-'}>
+CONFIG_SND_BCM2835_SOC_I2S                      policy<{'arm64': '-'}>
+CONFIG_SND_BCM63XX_I2S_WHISTLER                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_BEBOB                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_BT87X                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_BT87X_OVERCLOCK                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_CA0106                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_CMIPCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_COMPRESS_OFFLOAD                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_CS4281                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_CS46XX                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_CS46XX_NEW_DSP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_CTL_LED                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_CTXFI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DARLA20                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DARLA24                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DESIGNWARE_I2S                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DESIGNWARE_PCM                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DICE                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DMAENGINE_PCM                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DMA_SGBUF                            policy<{'amd64': '-'}>
+CONFIG_SND_DRIVERS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DUMMY                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_DYNAMIC_MINORS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ECHO3G                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_EMU10K1                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_EMU10K1X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_EMU10K1_SEQ                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ENS1370                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ENS1371                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ES1938                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ES1968                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ES1968_INPUT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ES1968_RADIO                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FIREFACE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FIREWIRE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FIREWIRE_DIGI00X                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FIREWIRE_LIB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FIREWIRE_MOTU                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FIREWIRE_TASCAM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FIREWORKS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FM801                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_FM801_TEA575X_BOOL                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_GINA20                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_GINA24                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_ALIGNED_MMIO                     policy<{'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_ANALOG                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_CA0110                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_CA0132                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_CA0132_DSP                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_CIRRUS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_CMEDIA                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_CONEXANT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_CS8409                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_HDMI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_REALTEK                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_SI3054                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_SIGMATEL                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CODEC_VIA                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_COMPONENT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_CORE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_DSP_LOADER                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_EXT_CORE                         policy<{'amd64': '-'}>
+CONFIG_SND_HDA_GENERIC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_GENERIC_LEDS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_HWDEP                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_I915                             policy<{'amd64': '-'}>
+CONFIG_SND_HDA_INPUT_BEEP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_INPUT_BEEP_MODE                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_INTEL                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_INTEL_HDMI_SILENT_STREAM         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_PATCH_LOADER                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_PREALLOC_SIZE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDA_TEGRA                            policy<{'arm64': '-'}>
+CONFIG_SND_HDSP                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HDSPM                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HRTIMER                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_HWDEP                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_I2S_HI6210_I2S                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ICE1712                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ICE1724                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_IMX_SOC                              policy<{'arm64': '-'}>
+CONFIG_SND_INDIGO                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INDIGODJ                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INDIGODJX                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INDIGOIO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INDIGOIOX                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INTEL8X0                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INTEL8X0M                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INTEL_BYT_PREFER_SOF                 policy<{'amd64': '-'}>
+CONFIG_SND_INTEL_DSP_CONFIG                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INTEL_NHLT                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_INTEL_SOUNDWIRE_ACPI                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_ISIGHT                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_JACK                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_JACK_INPUT_DEV                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_KIRKWOOD_SOC                         policy<{'arm64': '-'}>
+CONFIG_SND_KIRKWOOD_SOC_ARMADA370_DB            policy<{'arm64': '-'}>
+CONFIG_SND_KORG1212                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_LAYLA20                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_LAYLA24                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_LOLA                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_LX6464ES                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MAESTRO3                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MAESTRO3_INPUT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MAX_CARDS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MESON_AIU                            policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_FIFO                       policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_FRDDR                      policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_PDM                        policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_SOUND_CARD                 policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_SPDIFIN                    policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_SPDIFOUT                   policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_TDMIN                      policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_TDMOUT                     policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_TDM_FORMATTER              policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_TDM_INTERFACE              policy<{'arm64': '-'}>
+CONFIG_SND_MESON_AXG_TODDR                      policy<{'arm64': '-'}>
+CONFIG_SND_MESON_CARD_UTILS                     policy<{'arm64': '-'}>
+CONFIG_SND_MESON_CODEC_GLUE                     policy<{'arm64': '-'}>
+CONFIG_SND_MESON_G12A_TOACODEC                  policy<{'arm64': '-'}>
+CONFIG_SND_MESON_G12A_TOHDMITX                  policy<{'arm64': '-'}>
+CONFIG_SND_MESON_GX_SOUND_CARD                  policy<{'arm64': '-'}>
+CONFIG_SND_MIA                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MIXART                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MIXER_OSS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MONA                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MPU401                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MPU401_UART                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MTPAV                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_MTS64                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_NM256                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_OPL3_LIB                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_OPL3_LIB_SEQ                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_OSSEMUL                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_OXFW                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_OXYGEN                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_OXYGEN_LIB                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PCI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PCM                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PCMCIA                               policy<{'amd64': '-'}>
+CONFIG_SND_PCM_ELD                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PCM_IEC958                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PCM_TIMER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PCSP                                 policy<{'amd64': '-'}>
+CONFIG_SND_PCXHR                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PDAUDIOCF                            policy<{'amd64': '-'}>
+CONFIG_SND_PORTMAN2X4                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_PROC_FS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_RAWMIDI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_RIPTIDE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_RME32                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_RME96                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_RME9652                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SB_COMMON                            policy<{'amd64': '-'}>
+CONFIG_SND_SEQUENCER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SEQUENCER_OSS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SEQ_DEVICE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SEQ_DUMMY                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SEQ_HRTIMER_DEFAULT                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SEQ_MIDI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SEQ_MIDI_EMUL                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SEQ_MIDI_EVENT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SEQ_VIRMIDI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SERIAL_U16550                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SIMPLE_CARD                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SIMPLE_CARD_UTILS                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AC97_BUS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AC97_CODEC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ACPI                             policy<{'amd64': '-'}>
+CONFIG_SND_SOC_ACPI_INTEL_MATCH                 policy<{'amd64': '-'}>
+CONFIG_SND_SOC_ADAU1372                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU1372_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU1372_SPI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU1701                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU1761                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU1761_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU1761_SPI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU17X1                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU7002                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU7118                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU7118_HW                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU7118_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADAU_UTILS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADI_AXI_I2S                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ADI_AXI_SPDIF                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AK4104                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AK4118                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AK4458                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AK4554                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AK4613                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AK4642                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AK5386                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AK5558                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ALC5623                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ALC5632                          policy<{'arm64': '-'}>
+CONFIG_SND_SOC_AMD_ACP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AMD_ACP3x                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_AMD_ACP5x                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_AMD_CZ_DA7219MX98357_MACH        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AMD_CZ_RT5645_MACH               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_AMD_RV_RT5682_MACH               policy<{'amd64': '-'}>
+CONFIG_SND_SOC_APQ8016_SBC                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_ARIZONA                          policy<{'amd64': '-'}>
+CONFIG_SND_SOC_BD28623                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_BT_SCO                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_COMPRESS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CPCAP                            policy<{'arm64': '-'}>
+CONFIG_SND_SOC_CROS_EC_CODEC                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L32                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L33                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L34                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L35                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS35L36                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS4234                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS4265                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS4270                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS4271                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS4271_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS4271_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS42L42                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS42L51                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS42L51_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS42L52                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS42L56                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS42L73                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS42XX8                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS42XX8_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS43130                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS4341                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS4349                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CS53L30                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_CX2072X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_DA7213                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_DA7219                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_DAVINCI_MCASP                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_DMIC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ES7134                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ES7241                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ES8316                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ES8328                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ES8328_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ES8328_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_ASOC_CARD                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_FSL_ASRC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_AUD2HTX                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_FSL_AUDMIX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_EASRC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_ESAI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_MICFIL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_MQS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_RPMSG                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_SAI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_SPDIF                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_SSI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_FSL_XCVR                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_GENERIC_DMAENGINE_PCM            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_GTM601                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_HDAC_HDA                         policy<{'amd64': '-'}>
+CONFIG_SND_SOC_HDAC_HDMI                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_HDMI_CODEC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_I2C_AND_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ICS43432                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMG_I2S_IN                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMG_I2S_OUT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMG_PARALLEL_OUT                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMG_PISTACHIO_INTERNAL_DAC       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMG_SPDIF_IN                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMG_SPDIF_OUT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMX_AUDIO_RPMSG                  policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_AUDMIX                       policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_AUDMUX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_IMX_CARD                         policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_ES8328                       policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_HDMI                         policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_PCM_DMA                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_PCM_RPMSG                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_RPMSG                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_SGTL5000                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_IMX_SPDIF                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_INNO_RK3036                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_INTEL_APL                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BDW_RT5650_MACH            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BDW_RT5677_MACH            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BROADWELL_MACH             policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BXT_DA7219_MAX98357A_COMMON policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BXT_DA7219_MAX98357A_MACH  policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BXT_RT298_MACH             policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BYTCR_RT5640_MACH          policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BYTCR_RT5651_MACH          policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BYTCR_WM5102_MACH          policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BYT_CHT_CX2072X_MACH       policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BYT_CHT_DA7213_MACH        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BYT_CHT_ES8316_MACH        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_BYT_CHT_NOCODEC_MACH       policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CATPT                      policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CHT_BSW_MAX98090_TI_MACH   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CHT_BSW_NAU8824_MACH       policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CHT_BSW_RT5645_MACH        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CHT_BSW_RT5672_MACH        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_CML_LP_DA7219_MAX98357A_MACH policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_DA7219_MAX98357A_GENERIC   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_EHL_RT5660_MACH            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_GLK                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_GLK_DA7219_MAX98357A_MACH  policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_GLK_RT5682_MAX98357A_MACH  policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_HASWELL_MACH               policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_HDA_DSP_COMMON             policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_KBL                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_KBL_DA7219_MAX98357A_MACH  policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_KBL_DA7219_MAX98927_MACH   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_KBL_RT5660_MACH            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_KBL_RT5663_MAX98927_MACH   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_KBL_RT5663_RT5514_MAX98927_MACH policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_KEEMBAY                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_INTEL_MACH                       policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKL                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKL_HDA_DSP_GENERIC_MACH   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKL_NAU88L25_MAX98357A_MACH policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKL_NAU88L25_SSM4567_MACH  policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKL_RT286_MACH             policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKYLAKE_COMMON             policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKYLAKE_FAMILY             policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SKYLAKE_SSP_CLK            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SOF_CML_RT1011_RT5682_MACH policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SOF_CS42L42_MACH           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SOF_DA7219_MAX98373_MACH   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SOF_MAXIM_COMMON           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SOF_PCM512x_MACH           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SOF_RT5682_MACH            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SOF_WM8804_MACH            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SST                        policy<{'amd64': '-'}>
+CONFIG_SND_SOC_INTEL_SST_TOPLEVEL               policy<{'amd64': '-'}>
+CONFIG_SND_SOC_J721E_EVM                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_LOCHNAGAR_SC                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_APQ8016                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_CPU                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_HDMI                       policy<{'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_IPQ806X                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_PLATFORM                   policy<{'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_RX_MACRO                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_SC7180                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_TX_MACRO                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_VA_MACRO                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_LPASS_WSA_MACRO                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX9759                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98088                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98090                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98357A                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98373                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98373_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98373_SDW                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98390                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98504                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX9860                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX9867                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MAX98927                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MEDIATEK                         policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MESON_T9015                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MIKROE_PROTO                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MSM8916_WCD_ANALOG               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MSM8916_WCD_DIGITAL              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MSM8996                          policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT2701                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT6351                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MT6358                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MT6359                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT6359_ACCDET                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT6660                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_MT6797                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT6797_MT6351                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT8173                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT8183                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT8183_DA7219_MAX98357A          policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT8183_MT6358_TS3A227E_MAX98357A policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT8192                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT8192_MT6359_RT1015_RT5682      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT8195                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MT8195_MT6359_RT1019_RT5682      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_MTK_BTCVSD                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_NAU8315                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_NAU8540                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_NAU8810                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_NAU8822                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_NAU8824                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_NAU8825                          policy<{'amd64': '-'}>
+CONFIG_SND_SOC_PCM1681                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM1789                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM1789_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM179X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM179X_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM179X_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM186X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM186X_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM186X_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM3060                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM3060_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM3060_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM3168A                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM3168A_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM3168A_SPI                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM5102A                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM512x                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM512x_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_PCM512x_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_QCOM                             policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QCOM_COMMON                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6                            policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_ADM                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_AFE                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_AFE_CLOCKS                 policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_AFE_DAI                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_ASM                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_ASM_DAI                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_COMMON                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_CORE                       policy<{'arm64': '-'}>
+CONFIG_SND_SOC_QDSP6_ROUTING                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_RCAR                             policy<{'arm64': '-'}>
+CONFIG_SND_SOC_RK3288_HDMI_ANALOG               policy<{'arm64': '-'}>
+CONFIG_SND_SOC_RK3328                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RK3399_GRU_SOUND                 policy<{'arm64': '-'}>
+CONFIG_SND_SOC_RK817                            policy<{'arm64': '-'}>
+CONFIG_SND_SOC_RL6231                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RL6347A                          policy<{'amd64': '-'}>
+CONFIG_SND_SOC_ROCKCHIP                         policy<{'arm64': '-'}>
+CONFIG_SND_SOC_ROCKCHIP_I2S                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_ROCKCHIP_MAX98090                policy<{'arm64': '-'}>
+CONFIG_SND_SOC_ROCKCHIP_PDM                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_ROCKCHIP_RT5645                  policy<{'arm64': '-'}>
+CONFIG_SND_SOC_ROCKCHIP_SPDIF                   policy<{'arm64': '-'}>
+CONFIG_SND_SOC_RT1011                           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_RT1015                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT1015P                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT1308                           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_RT1308_SDW                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT1316_SDW                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT286                            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_RT298                            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_RT5514                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5514_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5616                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5631                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5640                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5645                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5651                           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_RT5659                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5660                           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_RT5663                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5670                           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_RT5677                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5677_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5682                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5682_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT5682_SDW                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT700                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT700_SDW                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT711                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT711_SDCA_SDW                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT711_SDW                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT715                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT715_SDCA_SDW                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RT715_SDW                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_RZ                               policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SC7180                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SDM845                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SDW_MOCKUP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SGTL5000                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SH4_FSI                          policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SI476X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SIGMADSP                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SIGMADSP_I2C                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SIGMADSP_REGMAP                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SIMPLE_AMPLIFIER                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SIMPLE_MUX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SM8250                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SOF_ACPI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SOF_ACPI_DEV                     policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_ALDERLAKE                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_APOLLOLAKE                   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_BAYTRAIL                     policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_BROADWELL                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_CANNONLAKE                   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_COFFEELAKE                   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_COMETLAKE                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_DEBUG_PROBES                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SOF_DEVELOPER_SUPPORT            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SOF_ELKHARTLAKE                  policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_GEMINILAKE                   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_HDA                          policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_HDA_COMMON                   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_HDA_LINK_BASELINE            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_ICELAKE                      policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_IMX8                         policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF_IMX8M                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF_IMX8M_SUPPORT                policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF_IMX8_SUPPORT                 policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF_IMX_COMMON                   policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF_IMX_OF                       policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF_IMX_TOPLEVEL                 policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_APL                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_ATOM_HIFI_EP           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_CNL                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_COMMON                 policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_HIFI_EP_IPC            policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_ICL                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_SOUNDWIRE              policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_SOUNDWIRE_LINK_BASELINE policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_TGL                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_INTEL_TOPLEVEL               policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_JASPERLAKE                   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_MERRIFIELD                   policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_OF                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SOF_PCI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SOF_PCI_DEV                      policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_PROBE_WORK_QUEUE             policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_TIGERLAKE                    policy<{'amd64': '-'}>
+CONFIG_SND_SOC_SOF_TOPLEVEL                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SOF_XTENSA                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SPDIF                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SPRD                             policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SPRD_MCDT                        policy<{'arm64': '-'}>
+CONFIG_SND_SOC_SSM2305                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SSM2518                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SSM2602                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SSM2602_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SSM2602_SPI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_SSM4567                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_STA32X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_STA350                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_STI_SAS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_STORM                            policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TAS2552                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TAS2562                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TAS2764                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TAS2770                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TAS5086                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TAS571X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TAS5720                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TAS6424                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TDA7419                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA                            policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA186_DSPK                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA20_AC97                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA20_DAS                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA20_I2S                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA20_SPDIF                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA210_ADMAIF                  policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA210_AHUB                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA210_DMIC                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA210_I2S                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA30_AHUB                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA30_I2S                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_ALC5632                    policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_AUDIO_GRAPH_CARD           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_MACHINE_DRV                policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_MAX98090                   policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_RT5640                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_RT5677                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_SGTL5000                   policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_TRIMSLICE                  policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_WM8753                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_WM8903                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TEGRA_WM9712                     policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TFA9879                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TFA989X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TI_EDMA_PCM                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TI_SDMA_PCM                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TI_UDMA_PCM                      policy<{'arm64': '-'}>
+CONFIG_SND_SOC_TLV320ADCX140                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC23                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC23_I2C                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC23_SPI                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC31XX                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC32X4                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC32X4_I2C                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC32X4_SPI                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC3X                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC3X_I2C                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TLV320AIC3X_SPI                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TOPOLOGY                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TPA6130A2                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TS3A227E                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TSCS42XX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_TSCS454                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_UDA1334                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WCD9335                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WCD934X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WCD938X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WCD938X_SDW                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WCD_MBHC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM5102                           policy<{'amd64': '-'}>
+CONFIG_SND_SOC_WM8510                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8523                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8524                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8580                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8711                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8728                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8731                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8737                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8741                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8750                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8753                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8770                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8776                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8782                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8804                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8804_I2C                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8804_SPI                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8903                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8904                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8960                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8962                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8974                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8978                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8985                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM8994                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_WM9712                           policy<{'arm64': '-'}>
+CONFIG_SND_SOC_WM_ADSP                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_WM_HUBS                          policy<{'arm64': '-'}>
+CONFIG_SND_SOC_WSA881X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_XILINX_AUDIO_FORMATTER           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_XILINX_I2S                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_XILINX_SPDIF                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_XTFPGA_I2S                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SOC_ZL38060                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SONICVIBES                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SPI                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SST_ATOM_HIFI2_PLATFORM              policy<{'amd64': '-'}>
+CONFIG_SND_SST_ATOM_HIFI2_PLATFORM_ACPI         policy<{'amd64': '-'}>
+CONFIG_SND_SST_ATOM_HIFI2_PLATFORM_PCI          policy<{'amd64': '-'}>
+CONFIG_SND_SUN4I_CODEC                          policy<{'arm64': '-'}>
+CONFIG_SND_SUN4I_I2S                            policy<{'arm64': '-'}>
+CONFIG_SND_SUN4I_SPDIF                          policy<{'arm64': '-'}>
+CONFIG_SND_SUN50I_CODEC_ANALOG                  policy<{'arm64': '-'}>
+CONFIG_SND_SUN8I_ADDA_PR_REGMAP                 policy<{'arm64': '-'}>
+CONFIG_SND_SUN8I_CODEC                          policy<{'arm64': '-'}>
+CONFIG_SND_SUN8I_CODEC_ANALOG                   policy<{'arm64': '-'}>
+CONFIG_SND_SUPPORT_OLD_API                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_SYNTH_EMUX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_TIMER                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_TRIDENT                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_6FIRE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_AUDIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_AUDIO_USE_MEDIA_CONTROLLER       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_CAIAQ                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_CAIAQ_INPUT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_HIFACE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_LINE6                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_POD                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_PODHD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_TONEPORT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_UA101                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_USB_US122L                           policy<{'amd64': '-'}>
+CONFIG_SND_USB_USX2Y                            policy<{'amd64': '-'}>
+CONFIG_SND_USB_VARIAX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VERBOSE_PRINTK                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VERBOSE_PROCFS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VIA82XX                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VIA82XX_MODEM                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VIRMIDI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VIRTIO                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VIRTUOSO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VMASTER                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VX222                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_VXPOCKET                             policy<{'amd64': '-'}>
+CONFIG_SND_VX_LIB                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_X86                                  policy<{'amd64': '-'}>
+CONFIG_SND_XEN_FRONTEND                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SND_YMFPCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SNI_NETSEC                               policy<{'arm64': '-'}>
+CONFIG_SOCFPGA_FPGA_BRIDGE                      policy<{'arm64': '-'}>
+CONFIG_SOCK_VALIDATE_XMIT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SOC_BRCMSTB                              policy<{'arm64': 'n'}>
+CONFIG_SOC_IMX8M                                policy<{'arm64': '-'}>
+CONFIG_SOC_RENESAS                              policy<{'arm64': '-'}>
+CONFIG_SOC_TEGRA_POWERGATE_BPMP                 policy<{'arm64': '-'}>
+CONFIG_SOC_TI                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SOFT_WATCHDOG_PRETIMEOUT                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SONYPI_COMPAT                            policy<{'amd64': '-'}>
+CONFIG_SONY_FF                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SONY_LAPTOP                              policy<{'amd64': '-'}>
+CONFIG_SOUNDWIRE_CADENCE                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SOUNDWIRE_GENERIC_ALLOCATION             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SOUNDWIRE_INTEL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SOUNDWIRE_QCOM                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SOUND_OSS_CORE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SP5100_TCO                               policy<{'amd64': 'n'}>
+CONFIG_SPARX5_SWITCH                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_ACNTSA                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_APOLLO                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_AUDPTR                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_BNS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_DECEXT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_DECTLK                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_DUMMY                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_LTLK                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_SOFT                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_SPKOUT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPEAKUP_SYNTH_TXPRT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI                                      policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_SPI_ALTERA                               policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_ALTERA_CORE                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_ALTERA_DFL                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_AMD                                  policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_ARMADA_3700                          policy<{'arm64': '-'}>
+CONFIG_SPI_AXI_SPI_ENGINE                       policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_BCM2835                              policy<{'arm64': 'n'}>
+CONFIG_SPI_BCM2835AUX                           policy<{'arm64': 'n'}>
+CONFIG_SPI_BCM_QSPI                             policy<{'arm64': 'y'}>
+CONFIG_SPI_BITBANG                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_BUTTERFLY                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_CADENCE                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_CADENCE_QUADSPI                      policy<{'arm64': 'n'}>
+CONFIG_SPI_DEBUG                                policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_DESIGNWARE                           policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_DLN2                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_DW_DMA                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_DW_MMIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_DW_PCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_DYNAMIC                              policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_SPI_FSI                                  policy<{'arm64': '-'}>
+CONFIG_SPI_FSL_DSPI                             policy<{'arm64': '-'}>
+CONFIG_SPI_FSL_LIB                              policy<{'arm64': '-'}>
+CONFIG_SPI_FSL_LPSPI                            policy<{'arm64': '-'}>
+CONFIG_SPI_FSL_QUADSPI                          policy<{'arm64': '-'}>
+CONFIG_SPI_FSL_SPI                              policy<{'arm64': 'n'}>
+CONFIG_SPI_GPIO                                 policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_HISI_KUNPENG                         policy<{'arm64': 'n'}>
+CONFIG_SPI_HISI_SFC                             policy<{'arm64': '-'}>
+CONFIG_SPI_HISI_SFC_V3XX                        policy<{'arm64': 'n'}>
+CONFIG_SPI_IMX                                  policy<{'arm64': '-'}>
+CONFIG_SPI_LANTIQ_SSC                           policy<{'amd64': '-'}>
+CONFIG_SPI_LJCA                                 policy<{'amd64': '-'}>
+CONFIG_SPI_LM70_LLP                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_LOOPBACK_TEST                        policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_MASTER                               policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_SPI_MEM                                  policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_MESON_SPICC                          policy<{'arm64': '-'}>
+CONFIG_SPI_MESON_SPIFC                          policy<{'arm64': '-'}>
+CONFIG_SPI_MT65XX                               policy<{'arm64': '-'}>
+CONFIG_SPI_MTK_NOR                              policy<{'arm64': '-'}>
+CONFIG_SPI_MUX                                  policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_MXIC                                 policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_NXP_FLEXSPI                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_OC_TINY                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_OMAP24XX                             policy<{'arm64': '-'}>
+CONFIG_SPI_ORION                                policy<{'arm64': '-'}>
+CONFIG_SPI_PL022                                policy<{'arm64': 'y'}>
+CONFIG_SPI_PXA2XX                               policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_PXA2XX_PCI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_QCOM_GENI                            policy<{'arm64': '-'}>
+CONFIG_SPI_QCOM_QSPI                            policy<{'arm64': '-'}>
+CONFIG_SPI_QUP                                  policy<{'arm64': '-'}>
+CONFIG_SPI_ROCKCHIP                             policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_ROCKCHIP_SFC                         policy<{'arm64': 'y'}>
+CONFIG_SPI_RPCIF                                policy<{'arm64': '-'}>
+CONFIG_SPI_RSPI                                 policy<{'arm64': '-'}>
+CONFIG_SPI_SC18IS602                            policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_SH_HSPI                              policy<{'arm64': '-'}>
+CONFIG_SPI_SH_MSIOF                             policy<{'arm64': '-'}>
+CONFIG_SPI_SIFIVE                               policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_SLAVE                                policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_SLAVE_MT27XX                         policy<{'arm64': '-'}>
+CONFIG_SPI_SLAVE_SYSTEM_CONTROL                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_SLAVE_TIME                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPI_SPIDEV                               policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_SPRD                                 policy<{'arm64': 'n'}>
+CONFIG_SPI_SPRD_ADI                             policy<{'arm64': '-'}>
+CONFIG_SPI_SUN4I                                policy<{'arm64': '-'}>
+CONFIG_SPI_SUN6I                                policy<{'arm64': '-'}>
+CONFIG_SPI_SYNQUACER                            policy<{'arm64': '-'}>
+CONFIG_SPI_TEGRA114                             policy<{'arm64': '-'}>
+CONFIG_SPI_TEGRA20_SFLASH                       policy<{'arm64': 'n'}>
+CONFIG_SPI_TEGRA20_SLINK                        policy<{'arm64': '-'}>
+CONFIG_SPI_TEGRA210_QUAD                        policy<{'arm64': 'n'}>
+CONFIG_SPI_THUNDERX                             policy<{'arm64': 'n'}>
+CONFIG_SPI_TLE62X0                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_XCOMM                                policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_XILINX                               policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPI_XLP                                  policy<{'arm64': '-'}>
+CONFIG_SPI_ZYNQMP_GQSPI                         policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_SPMI                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SPMI_HISI3670                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPMI_MSM_PMIC_ARB                        policy<{'arm64': '-'}>
+CONFIG_SPMI_PMIC_CLKDIV                         policy<{'arm64': '-'}>
+CONFIG_SPRD_COMMON_CLK                          policy<{'arm64': 'y'}>
+CONFIG_SPRD_DMA                                 policy<{'arm64': 'n'}>
+CONFIG_SPRD_EFUSE                               policy<{'arm64': 'n'}>
+CONFIG_SPRD_IOMMU                               policy<{'arm64': 'n'}>
+CONFIG_SPRD_MBOX                                policy<{'arm64': 'n'}>
+CONFIG_SPRD_SC9860_CLK                          policy<{'arm64': 'y'}>
+CONFIG_SPRD_SC9863A_CLK                         policy<{'arm64': 'y'}>
+CONFIG_SPRD_THERMAL                             policy<{'arm64': 'n'}>
+CONFIG_SPRD_WATCHDOG                            policy<{'arm64': 'n'}>
+CONFIG_SPS30                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPS30_I2C                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SPS30_SERIAL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SQUASHFS_LZ4                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SQUASHFS_LZO                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SQUASHFS_XZ                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SQUASHFS_ZSTD                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SRAM                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SRF04                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SRF08                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SSB_B43_PCI_BRIDGE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SSB_BLOCKIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SSB_DRIVER_GPIO                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SSB_PCMCIAHOST                           policy<{'amd64': '-'}>
+CONFIG_SSB_PCMCIAHOST_POSSIBLE                  policy<{'amd64': '-'}>
+CONFIG_SSB_SDIOHOST                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SSFDC                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_STACK_TRACER                             policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_STAGING                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_STAGING_BOARD                            policy<{'arm64': '-'}>
+CONFIG_STAGING_MEDIA                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STANDALONE                               policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_STE10XP                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_STK3310                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STK8312                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STK8BA50                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STM                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_STMMAC_ETH                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STMMAC_PCI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STMMAC_PLATFORM                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STMMAC_SELFTESTS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STMPE_ADC                                policy<{'arm64': '-'}>
+CONFIG_STMPE_I2C                                policy<{'arm64': '-'}>
+CONFIG_STMPE_SPI                                policy<{'arm64': '-'}>
+CONFIG_STMP_DEVICE                              policy<{'arm64': '-'}>
+CONFIG_STM_DUMMY                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STM_PROTO_BASIC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STM_PROTO_SYS_T                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STM_SOURCE_CONSOLE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STM_SOURCE_FTRACE                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STM_SOURCE_HEARTBEAT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STPMIC1_WATCHDOG                         policy<{'arm64': '-'}>
+CONFIG_STREAM_PARSER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_STRIP_ASM_SYMS                           policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_STUB_CLK_HI3660                          policy<{'arm64': '-'}>
+CONFIG_STUB_CLK_HI6220                          policy<{'arm64': '-'}>
+CONFIG_STX104                                   policy<{'amd64': '-'}>
+CONFIG_ST_UVIS25                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ST_UVIS25_I2C                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ST_UVIS25_SPI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SUN4I_EMAC                               policy<{'arm64': '-'}>
+CONFIG_SUN4I_GPADC                              policy<{'arm64': '-'}>
+CONFIG_SUN4I_TIMER                              policy<{'arm64': '-'}>
+CONFIG_SUN50I_A100_CCU                          policy<{'arm64': '-'}>
+CONFIG_SUN50I_A100_R_CCU                        policy<{'arm64': '-'}>
+CONFIG_SUN50I_A64_CCU                           policy<{'arm64': '-'}>
+CONFIG_SUN50I_DE2_BUS                           policy<{'arm64': '-'}>
+CONFIG_SUN50I_ERRATUM_UNKNOWN1                  policy<{'arm64': '-'}>
+CONFIG_SUN50I_H616_CCU                          policy<{'arm64': '-'}>
+CONFIG_SUN50I_H6_CCU                            policy<{'arm64': '-'}>
+CONFIG_SUN50I_H6_R_CCU                          policy<{'arm64': '-'}>
+CONFIG_SUN50I_IOMMU                             policy<{'arm64': '-'}>
+CONFIG_SUN6I_MSGBOX                             policy<{'arm64': '-'}>
+CONFIG_SUN8I_A83T_CCU                           policy<{'arm64': '-'}>
+CONFIG_SUN8I_DE2_CCU                            policy<{'arm64': '-'}>
+CONFIG_SUN8I_H3_CCU                             policy<{'arm64': '-'}>
+CONFIG_SUN8I_R_CCU                              policy<{'arm64': '-'}>
+CONFIG_SUN8I_THERMAL                            policy<{'arm64': '-'}>
+CONFIG_SUNGEM                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SUNGEM_PHY                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SUNRPC_DISABLE_INSECURE_ENCTYPES         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SUNRPC_SWAP                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SUNRPC_XPRT_RDMA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SUNXI_CCU                                policy<{'arm64': '-'}>
+CONFIG_SUNXI_MBUS                               policy<{'arm64': '-'}>
+CONFIG_SUNXI_RSB                                policy<{'arm64': '-'}>
+CONFIG_SUNXI_SRAM                               policy<{'arm64': '-'}>
+CONFIG_SUNXI_WATCHDOG                           policy<{'arm64': '-'}>
+CONFIG_SUN_PARTITION                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SURFACE3_WMI                             policy<{'amd64': '-'}>
+CONFIG_SURFACE_3_BUTTON                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_3_POWER_OPREGION                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SURFACE_ACPI_NOTIFY                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_AGGREGATOR                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SURFACE_AGGREGATOR_BUS                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_AGGREGATOR_CDEV                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_AGGREGATOR_ERROR_INJECTION       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_AGGREGATOR_REGISTRY              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_DTX                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_GPE                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SURFACE_HID                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_HID_CORE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_HOTPLUG                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SURFACE_KBD                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_PLATFORM_PROFILE                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SURFACE_PRO3_BUTTON                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SVC_I3C_MASTER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SW_SYNC                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SX9310                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SX9500                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SXGBE_ETH                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SYNCLINK_CS                              policy<{'amd64': '-'}>
+CONFIG_SYNCLINK_GT                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SYNC_FILE                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SYNTH_EVENTS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SYNTH_EVENT_GEN_TEST                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SYSCON_REBOOT_MODE                       policy<{'arm64': 'n'}>
+CONFIG_SYSC_R8A774A1                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A774B1                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A774C0                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A774E1                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A7795                             policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A77960                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A77961                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A77965                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A77970                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A77980                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A77990                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A77995                            policy<{'arm64': '-'}>
+CONFIG_SYSC_R8A779A0                            policy<{'arm64': '-'}>
+CONFIG_SYSC_RCAR                                policy<{'arm64': '-'}>
+CONFIG_SYSFB_SIMPLEFB                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SYSTEM76_ACPI                            policy<{'amd64': 'n'}>
+CONFIG_SYSTEMPORT                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SYSTEM_BLACKLIST_HASH_LIST               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SYSTEM_BLACKLIST_KEYRING                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SYSTEM_EXTRA_CERTIFICATE                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SYSTEM_EXTRA_CERTIFICATE_SIZE            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SYSTEM_REVOCATION_KEYS                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SYSTEM_REVOCATION_LIST                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_SYSV68_PARTITION                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SYSV_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SYS_SUPPORTS_SH_CMT                      policy<{'arm64': '-'}>
+CONFIG_SYS_SUPPORTS_SH_TMU                      policy<{'arm64': '-'}>
+CONFIG_T5403                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TABLET_SERIAL_WACOM4                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TABLET_USB_ACECAD                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TABLET_USB_AIPTEK                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TABLET_USB_HANWANG                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TABLET_USB_KBTAB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TABLET_USB_PEGASUS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TAHVO_USB                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TAHVO_USB_HOST_BY_DEFAULT                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TASKS_RCU                                policy<{'arm64': 'y'}>
+CONFIG_TASKS_RUDE_RCU                           policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_TASK_DELAY_ACCT                          policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_TCG_FTPM_TEE                             policy<{'arm64': '-'}>
+CONFIG_TCG_INFINEON                             policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_TCG_TIS                                  policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_TCG_TIS_CORE                             policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_TCG_TIS_I2C_CR50                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCG_TIS_SPI                              policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_TCG_TIS_SPI_CR50                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TCG_TIS_ST33ZP24                         policy<{'amd64': '-', 'arm64': 'm'}>
+CONFIG_TCG_TIS_ST33ZP24_I2C                     policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_TCG_TIS_ST33ZP24_SPI                     policy<{'amd64': '-', 'arm64': 'm'}>
+CONFIG_TCG_TIS_SYNQUACER                        policy<{'arm64': '-'}>
+CONFIG_TCM_FC                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCM_QLA2XXX                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCM_QLA2XXX_DEBUG                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TCP_CONG_BIC                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_CDG                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_DCTCP                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_HSTCP                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_HTCP                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_ILLINOIS                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_LP                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_NV                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_SCALABLE                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_VEGAS                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_VENO                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_WESTWOOD                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCP_CONG_YEAH                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TCS3414                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TCS3472                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TEE                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TEE_BNXT_FW                              policy<{'arm64': '-'}>
+CONFIG_TEGRA20_APB_DMA                          policy<{'arm64': 'n'}>
+CONFIG_TEGRA210_ADMA                            policy<{'arm64': '-'}>
+CONFIG_TEGRA210_EMC                             policy<{'arm64': '-'}>
+CONFIG_TEGRA210_EMC_TABLE                       policy<{'arm64': '-'}>
+CONFIG_TEGRA_ACONNECT                           policy<{'arm64': '-'}>
+CONFIG_TEGRA_BPMP                               policy<{'arm64': '-'}>
+CONFIG_TEGRA_BPMP_THERMAL                       policy<{'arm64': '-'}>
+CONFIG_TEGRA_CLK_DFLL                           policy<{'arm64': '-'}>
+CONFIG_TEGRA_GMI                                policy<{'arm64': 'n'}>
+CONFIG_TEGRA_HOST1X                             policy<{'arm64': 'n'}>
+CONFIG_TEGRA_HOST1X_FIREWALL                    policy<{'arm64': '-'}>
+CONFIG_TEGRA_HSP_MBOX                           policy<{'arm64': 'n'}>
+CONFIG_TEGRA_IOMMU_SMMU                         policy<{'arm64': '-'}>
+CONFIG_TEGRA_IVC                                policy<{'arm64': 'n'}>
+CONFIG_TEGRA_MC                                 policy<{'arm64': '-'}>
+CONFIG_TEGRA_TIMER                              policy<{'arm64': '-'}>
+CONFIG_TEGRA_VDE                                policy<{'arm64': '-'}>
+CONFIG_TEGRA_WATCHDOG                           policy<{'arm64': 'n'}>
+CONFIG_TEHUTI                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TELCLOCK                                 policy<{'amd64': 'n'}>
+CONFIG_TERANETICS_PHY                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TEST_BPF                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TEST_DIV64                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TEST_HMM                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TEST_LIVEPATCH                           policy<{'amd64': '-'}>
+CONFIG_TEST_OBJAGG                              policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_TEST_PARMAN                              policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_TEST_POWER                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TEST_UBSAN                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_THERMAL_DEFAULT_GOV_POWER_ALLOCATOR      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_THERMAL_EMULATION                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_THERMAL_GOV_BANG_BANG                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_THERMAL_GOV_FAIR_SHARE                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_THERMAL_GOV_POWER_ALLOCATOR              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_THERMAL_GOV_USER_SPACE                   policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_THERMAL_HWMON                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_THERMAL_MMIO                             policy<{'arm64': 'n'}>
+CONFIG_THERMAL_NETLINK                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_THERMAL_STATISTICS                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_THERMAL_WRITABLE_TRIPS                   policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_THINKPAD_ACPI                            policy<{'amd64': '-'}>
+CONFIG_THINKPAD_ACPI_ALSA_SUPPORT               policy<{'amd64': '-'}>
+CONFIG_THINKPAD_ACPI_DEBUG                      policy<{'amd64': '-'}>
+CONFIG_THINKPAD_ACPI_DEBUGFACILITIES            policy<{'amd64': '-'}>
+CONFIG_THINKPAD_ACPI_HOTKEY_POLL                policy<{'amd64': '-'}>
+CONFIG_THINKPAD_ACPI_UNSAFE_LEDS                policy<{'amd64': '-'}>
+CONFIG_THINKPAD_ACPI_VIDEO                      policy<{'amd64': '-'}>
+CONFIG_THINKPAD_LMI                             policy<{'amd64': '-'}>
+CONFIG_THRUSTMASTER_FF                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_THUNDERX2_PMU                            policy<{'arm64': '-'}>
+CONFIG_THUNDER_NIC_BGX                          policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_THUNDER_NIC_PF                           policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_THUNDER_NIC_RGX                          policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_THUNDER_NIC_VF                           policy<{'amd64': 'n', 'arm64': 'y'}>
+CONFIG_TIFM_7XX1                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TIFM_CORE                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TIMER_IMX_SYS_CTR                        policy<{'arm64': '-'}>
+CONFIG_TINYDRM_HX8357D                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TINYDRM_ILI9225                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TINYDRM_ILI9341                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TINYDRM_ILI9486                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TINYDRM_MI0283QT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TINYDRM_REPAPER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TINYDRM_ST7586                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TINYDRM_ST7735R                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TIPC                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TIPC_CRYPTO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TIPC_DIAG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TIPC_MEDIA_IB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TIPC_MEDIA_UDP                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADC081C                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADC0832                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADC084S021                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADC108S102                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADC12138                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADC128S052                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADC161S626                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADS1015                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADS124S08                             policy<{'arm64': '-'}>
+CONFIG_TI_ADS131E08                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADS7950                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_ADS8344                               policy<{'arm64': '-'}>
+CONFIG_TI_ADS8688                               policy<{'arm64': '-'}>
+CONFIG_TI_AM335X_ADC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_AM65_CPSW_TAS                         policy<{'arm64': '-'}>
+CONFIG_TI_CPSW_PHY_SEL                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_DAC082S085                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_DAC5571                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_DAC7311                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_DAC7612                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_DAVINCI_MDIO                          policy<{'arm64': '-'}>
+CONFIG_TI_K3_AM65_CPSW_NUSS                     policy<{'arm64': '-'}>
+CONFIG_TI_K3_AM65_CPSW_SWITCHDEV                policy<{'arm64': '-'}>
+CONFIG_TI_K3_AM65_CPTS                          policy<{'arm64': '-'}>
+CONFIG_TI_K3_DSP_REMOTEPROC                     policy<{'arm64': '-'}>
+CONFIG_TI_K3_PSIL                               policy<{'arm64': '-'}>
+CONFIG_TI_K3_R5_REMOTEPROC                      policy<{'arm64': '-'}>
+CONFIG_TI_K3_RINGACC                            policy<{'arm64': '-'}>
+CONFIG_TI_K3_SOCINFO                            policy<{'arm64': '-'}>
+CONFIG_TI_K3_UDMA                               policy<{'arm64': '-'}>
+CONFIG_TI_K3_UDMA_GLUE_LAYER                    policy<{'arm64': '-'}>
+CONFIG_TI_MESSAGE_MANAGER                       policy<{'arm64': '-'}>
+CONFIG_TI_PRUSS                                 policy<{'arm64': '-'}>
+CONFIG_TI_PRUSS_INTC                            policy<{'arm64': '-'}>
+CONFIG_TI_SCI_CLK                               policy<{'arm64': '-'}>
+CONFIG_TI_SCI_CLK_PROBE_FROM_FW                 policy<{'arm64': '-'}>
+CONFIG_TI_SCI_INTA_IRQCHIP                      policy<{'arm64': '-'}>
+CONFIG_TI_SCI_INTA_MSI_DOMAIN                   policy<{'arm64': '-'}>
+CONFIG_TI_SCI_INTR_IRQCHIP                      policy<{'arm64': '-'}>
+CONFIG_TI_SCI_PM_DOMAINS                        policy<{'arm64': '-'}>
+CONFIG_TI_SCI_PROTOCOL                          policy<{'arm64': '-'}>
+CONFIG_TI_SOC_THERMAL                           policy<{'arm64': '-'}>
+CONFIG_TI_ST                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TI_SYSCON_CLK                            policy<{'arm64': '-'}>
+CONFIG_TI_TLC4541                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TI_TSC2046                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TLAN                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TLS                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TLS_DEVICE                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TLS_TOE                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TMD_HERMES                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TMP006                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TMP007                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TMP117                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TMPFS_INODE64                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TOPSTAR_LAPTOP                           policy<{'amd64': 'n'}>
+CONFIG_TOSHIBA_BT_RFKILL                        policy<{'amd64': 'n'}>
+CONFIG_TOSHIBA_HAPS                             policy<{'amd64': 'n'}>
+CONFIG_TOSHIBA_WMI                              policy<{'amd64': '-'}>
+CONFIG_TOUCHSCREEN_88PM860X                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_AD7877                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_AD7879                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_AD7879_I2C                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_AD7879_SPI                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ADC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ADS7846                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_AR1021_I2C                   policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ATMEL_MXT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ATMEL_MXT_T37                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_AUO_PIXCIR                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_BU21013                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_BU21029                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CHIPONE_ICN8318              policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CHIPONE_ICN8505              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_COLIBRI_VF50                 policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CY8CTMA140                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CY8CTMG110                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CYTTSP4_CORE                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CYTTSP4_I2C                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CYTTSP4_SPI                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CYTTSP_CORE                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CYTTSP_I2C                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_CYTTSP_SPI                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_DA9034                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_DA9052                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_DMI                          policy<{'amd64': '-'}>
+CONFIG_TOUCHSCREEN_DYNAPRO                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_EDT_FT5X06                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_EETI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_EGALAX                       policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_EGALAX_SERIAL                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_EKTF2127                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ELO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_EXC3000                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_FUJITSU                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_GOODIX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_GUNZE                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_HAMPSHIRE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_HIDEEP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_HYCON_HY46XX                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ILI210X                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ILITEK                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_IMX6UL_TSC                   policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_INEXIO                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_IPROC                        policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_IQS5XX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_MAX11801                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_MC13783                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_MCS5000                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_MELFAS_MIP4                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_MK712                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_MMS114                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_MSG2638                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_MTOUCH                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_PCAP                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_PENMOUNT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_PIXCIR                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_RASPBERRYPI_FW               policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_RM_TS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ROHM_BU21023                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_S6SY761                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_SILEAD                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_SIS_I2C                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ST1232                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_STMFTS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_STMPE                        policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_SUN4I                        policy<{'arm64': '-'}>
+CONFIG_TOUCHSCREEN_SUR40                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_SURFACE3_SPI                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_SX8654                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TI_AM335X_TSC                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TOUCHIT213                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TOUCHRIGHT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TOUCHWIN                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TPS6507X                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TSC2004                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TSC2005                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TSC2007                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TSC2007_IIO                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TSC200X_CORE                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_TSC_SERIO                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_UCB1400                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_3M                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_COMPOSITE                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_DMC_TSC10                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_E2I                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_EASYTOUCH                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_EGALAX                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_ELO                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_ETT_TC45USB              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_ETURBO                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_GENERAL_TOUCH            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_GOTOP                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_GUNZE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_IDEALTEK                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_IRTOUCH                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_ITM                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_JASTEC                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_NEXIO                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_PANJIT                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_USB_ZYTRONIC                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_WACOM_I2C                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_WACOM_W8001                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_WDT87XX_I2C                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_WM831X                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_WM9705                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_WM9712                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_WM9713                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_WM97XX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ZET6223                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ZFORCE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TOUCHSCREEN_ZINITIX                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TPL0102                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TPM_KEY_PARSER                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TPS6105X                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TPS65010                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TPS6507X                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TPS68470_PMIC_OPREGION                   policy<{'amd64': '-'}>
+CONFIG_TQMX86_WDT                               policy<{'amd64': 'n'}>
+CONFIG_TRACER_MAX_TRACE                         policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_TRACER_SNAPSHOT                          policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_TRACER_SNAPSHOT_PER_CPU_SWAP             policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_TRACE_EVENT_INJECT                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TRACING_MAP                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TRANSPARENT_HUGEPAGE_ALWAYS              policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_TRANSPARENT_HUGEPAGE_MADVISE             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TRUSTED_KEYS                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_TSL2583                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TSL2591                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TSL2772                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TSL4531                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TSYS01                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TSYS02D                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TTPCI_EEPROM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TULIP_MMIO                               policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_TULIP_NAPI                               policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_TULIP_NAPI_HW_MITIGATION                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TUN                                      policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_TURRIS_MOX_RWTM                          policy<{'arm64': '-'}>
+CONFIG_TWL4030_CORE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TWL4030_MADC                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TWL4030_WATCHDOG                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TWL6030_GPADC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TWL6040_CORE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_TYPEC_DP_ALTMODE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_FUSB302                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_HD3SS3220                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_MT6360                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_MUX_INTEL_PMC                      policy<{'amd64': '-'}>
+CONFIG_TYPEC_MUX_PI3USB30532                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_NVIDIA_ALTMODE                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_QCOM_PMIC                          policy<{'arm64': '-'}>
+CONFIG_TYPEC_RT1711H                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_STUSB160X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_TCPCI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_TCPCI_MAXIM                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_TCPM                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_TPS6598X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_UCSI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_TYPEC_WCOVE                              policy<{'amd64': '-'}>
+CONFIG_TYPHOON                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UACCE                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UBIFS_ATIME_SUPPORT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBIFS_FS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBIFS_FS_ADVANCED_COMPR                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBIFS_FS_AUTHENTICATION                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBIFS_FS_LZO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBIFS_FS_SECURITY                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBIFS_FS_XATTR                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBIFS_FS_ZLIB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBIFS_FS_ZSTD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_ALIGNMENT                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_BOOL                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_BOUNDS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_DIV_ZERO                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_ENUM                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_ONLY_BOUNDS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_SANITIZE_ALL                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_SHIFT                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_TRAP                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UBSAN_UNREACHABLE                        policy<{'arm64': '-'}>
 CONFIG_UBUNTU_ODM_DRIVERS                       policy<{'amd64': '-'}>
+CONFIG_UCB1400_CORE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UCC                                      policy<{'arm64': '-'}>
+CONFIG_UCC_FAST                                 policy<{'arm64': '-'}>
+CONFIG_UCC_SLOW                                 policy<{'arm64': '-'}>
+CONFIG_UCLAMP_BUCKETS_COUNT                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UCLAMP_TASK                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UCLAMP_TASK_GROUP                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UCSI_ACPI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UCSI_CCG                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UDMABUF                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UEFI_CPER                                policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_UEFI_CPER_ARM                            policy<{'arm64': '-'}>
+CONFIG_UFS_DEBUG                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UFS_FS_WRITE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UHID                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_AEC                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_CIF                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_DFL                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UIO_DMEM_GENIRQ                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_HV_GENERIC                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_MF624                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_NETX                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_PCI_GENERIC                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_PDRV_GENIRQ                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_PRUSS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UIO_SERCOS3                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ULI526X                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ULTRIX_PARTITION                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UNICODE                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_UNICODE_NORMALIZATION_SELFTEST           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UNINLINE_SPIN_UNLOCK                     policy<{'arm64': 'y'}>
+CONFIG_UNISYSSPAR                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UNISYS_VISORBUS                          policy<{'amd64': 'n'}>
+CONFIG_UNISYS_VISORHBA                          policy<{'amd64': '-'}>
+CONFIG_UNISYS_VISORINPUT                        policy<{'amd64': '-'}>
+CONFIG_UNISYS_VISORNIC                          policy<{'amd64': '-'}>
+CONFIG_UNWINDER_ORC                             policy<{'amd64': 'y'}>
+CONFIG_US5182D                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB                                      policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB4                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB4_DEBUGFS_WRITE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB4_DMA_TEST                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB4_NET                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USBIP_CORE                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USBIP_DEBUG                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USBIP_HOST                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USBIP_VHCI_HCD                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USBIP_VHCI_HC_PORTS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USBIP_VHCI_NR_HCS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USBIP_VUDC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USBPCWATCHDOG                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ADUTUX                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_AIRSPY                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_ALI_M5632                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_AMD5536UDC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_AN2720                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ANNOUNCE_NEW_DEVICES                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_APPLEDISPLAY                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ATM                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_AUDIO                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_BDC_UDC                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_BRCMSTB                              policy<{'arm64': '-'}>
+CONFIG_USB_C67X00_HCD                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_CATC                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_CDC_COMPOSITE                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDC_PHONET                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNS3                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNS3_GADGET                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNS3_HOST                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNS3_IMX                            policy<{'arm64': '-'}>
+CONFIG_USB_CDNS3_PCI_WRAP                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNS3_TI                             policy<{'arm64': '-'}>
+CONFIG_USB_CDNSP_GADGET                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNSP_HOST                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNSP_PCI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNS_HOST                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CDNS_SUPPORT                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_CHAOSKEY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_CHIPIDEA                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_CHIPIDEA_GENERIC                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CHIPIDEA_HOST                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CHIPIDEA_IMX                         policy<{'arm64': '-'}>
+CONFIG_USB_CHIPIDEA_MSM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CHIPIDEA_PCI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CHIPIDEA_TEGRA                       policy<{'arm64': '-'}>
+CONFIG_USB_CHIPIDEA_UDC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_COMMON                               policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_CONFIGFS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_ACM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_ECM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_ECM_SUBSET                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_EEM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_FS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_HID                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_LB_SS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_MIDI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_PRINTER                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_TCM                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_UAC1                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_UAC1_LEGACY               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_UAC2                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_F_UVC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_MASS_STORAGE                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_NCM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_OBEX                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_PHONET                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_RNDIS                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONFIGFS_SERIAL                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CONN_GPIO                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_CXACRU                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_CYPRESS_CY7C63                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_CYTHERM                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_DSBR                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DUMMY_HCD                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC2                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_DWC2_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC2_HOST                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC2_PCI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC2_TRACK_MISSED_SOFS               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC3                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_DWC3_DUAL_ROLE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC3_GADGET                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC3_HAPS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC3_HOST                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC3_IMX8MP                          policy<{'arm64': '-'}>
+CONFIG_USB_DWC3_KEYSTONE                        policy<{'arm64': '-'}>
+CONFIG_USB_DWC3_MESON_G12A                      policy<{'arm64': '-'}>
+CONFIG_USB_DWC3_OF_SIMPLE                       policy<{'arm64': '-'}>
+CONFIG_USB_DWC3_PCI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC3_QCOM                            policy<{'arm64': '-'}>
+CONFIG_USB_DWC3_ULPI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_DWC3_XILINX                          policy<{'arm64': '-'}>
+CONFIG_USB_DYNAMIC_MINORS                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_EG20T                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_EHCI_BRCMSTB                         policy<{'arm64': '-'}>
+CONFIG_USB_EHCI_FSL                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_EHCI_HCD_ORION                       policy<{'arm64': '-'}>
+CONFIG_USB_EHCI_PCI                             policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_EHCI_ROOT_HUB_TT                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_EHCI_TEGRA                           policy<{'arm64': 'n'}>
+CONFIG_USB_EHSET_TEST_FIXTURE                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_EMI26                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_EMI62                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_EMXX                                 policy<{'arm64': '-'}>
+CONFIG_USB_EPSON2888                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ETH                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_ETH_EEM                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_ETH_RNDIS                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_EZUSB_FX2                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_FOTG210_HCD                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_FOTG210_UDC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_FTDI_ELAN                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_FUNCTIONFS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_FUNCTIONFS_ETH                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_FUNCTIONFS_GENERIC                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_FUNCTIONFS_RNDIS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_ACM                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_ECM                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_EEM                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_FS                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_HID                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_MASS_STORAGE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_MIDI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_NCM                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_OBEX                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_PHONET                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_PRINTER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_RNDIS                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_SERIAL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_SS_LB                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_SUBSET                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_TCM                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_UAC1                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_UAC1_LEGACY                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_UAC2                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_F_UVC                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GADGET                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_GADGETFS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GADGET_DEBUG                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GADGET_DEBUG_FILES                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GADGET_DEBUG_FS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GADGET_STORAGE_NUM_BUFFERS           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GADGET_TARGET                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GADGET_VBUS_DRAW                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GADGET_XILINX                        policy<{'arm64': '-'}>
+CONFIG_USB_GL860                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GOKU                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GPIO_VBUS                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_GR_UDC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_BENQ                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_CONEX                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_CPIA1                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_DTCS033                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_ETOMS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_FINEPIX                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_JEILINJ                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_JL2005BCD                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_KINECT                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_KONICA                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_MARS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_MR97310A                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_NW80X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_OV519                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_OV534                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_OV534_9                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_PAC207                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_PAC7302                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_PAC7311                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SE401                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SN9C2028                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SN9C20X                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SONIXB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SONIXJ                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SPCA1528                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SPCA500                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SPCA501                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SPCA505                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SPCA506                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SPCA508                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SPCA561                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SQ905                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SQ905C                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SQ930X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_STK014                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_STK1135                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_STV0680                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_SUNPLUS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_T613                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_TOPRO                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_TOUPTEK                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_TV8532                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_VC032X                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_VICAM                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_XIRLINK_CIT                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_GSPCA_ZC3XX                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_ACM_MS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_DBGP                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_DBGP_PRINTK                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_DBGP_SERIAL                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_HID                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_MULTI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_NCM                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_NOKIA                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_PRINTER                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_SERIAL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_G_WEBCAM                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_HACKRF                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_HSIC_USB3503                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_HSIC_USB4604                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_HSO                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_HUB_USB251XB                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_IDMOUSE                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_IOWARRIOR                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_IPHETH                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ISIGHTFW                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ISP116X_HCD                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ISP1301                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ISP1760                              policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_USB_ISP1760_DUAL_ROLE                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_ISP1760_GADGET_ROLE                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_ISP1760_HCD                          policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_USB_ISP1760_HOST_ROLE                    policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_USB_ISP1761_UDC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_KAWETH                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_KBD                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_KC2190                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_KEENE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_LAN78XX                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_LCD                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_LD                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_LEDS_TRIGGER_USBPORT                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_LED_TRIG                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_LEGOTOWER                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_LGM_PHY                              policy<{'amd64': 'n'}>
+CONFIG_USB_LIBCOMPOSITE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_LINK_LAYER_TEST                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_M5602                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MA901                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MASS_STORAGE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MAX3420_UDC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MAX3421_HCD                          policy<{'amd64': '-', 'arm64': 'n'}>
+CONFIG_USB_MDC800                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_MICROTEK                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_MIDI_GADGET                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MON                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_MOUSE                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_MR800                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MSI2500                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MTU3                                 policy<{'arm64': '-'}>
+CONFIG_USB_MTU3_DEBUG                           policy<{'arm64': '-'}>
+CONFIG_USB_MTU3_DUAL_ROLE                       policy<{'arm64': '-'}>
+CONFIG_USB_MTU3_GADGET                          policy<{'arm64': '-'}>
+CONFIG_USB_MTU3_HOST                            policy<{'arm64': '-'}>
+CONFIG_USB_MUSB_DUAL_ROLE                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MUSB_GADGET                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MUSB_HOST                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MUSB_MEDIATEK                        policy<{'arm64': '-'}>
+CONFIG_USB_MUSB_SUNXI                           policy<{'arm64': '-'}>
+CONFIG_USB_MV_U3D                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MV_UDC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_MXS_PHY                              policy<{'arm64': '-'}>
+CONFIG_USB_NET2272                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_NET2272_DMA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_NET2280                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_NET_AQC111                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_CDC_EEM                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_CDC_MBIM                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_CH9200                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_CX82310_ETH                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_DM9601                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_GL620A                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_HUAWEI_CDC_NCM                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_INT51X1                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_KALMIA                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_MCS7830                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_PLUSB                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_QMI_WWAN                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_RNDIS_HOST                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_RNDIS_WLAN                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_NET_SMSC75XX                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_SMSC95XX                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_SR9700                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_NET_SR9800                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_OHCI_HCD_PCI                         policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_OHCI_HCD_PLATFORM                    policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_OHCI_HCD_SSB                         policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_USB_OXU210HP_HCD                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_PEGASUS                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_PHY                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_PRINTER                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_PULSE8_CEC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_PWC                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_PWC_DEBUG                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_PWC_INPUT_EVDEV                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_PXA27X                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_R8A66597                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_R8A66597_HCD                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_RAINSHADOW_CEC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_RAREMONO                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_RAW_GADGET                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_RENESAS_USB3                         policy<{'arm64': '-'}>
+CONFIG_USB_RENESAS_USBHS                        policy<{'arm64': '-'}>
+CONFIG_USB_RENESAS_USBHS_HCD                    policy<{'arm64': '-'}>
+CONFIG_USB_RENESAS_USBHS_UDC                    policy<{'arm64': '-'}>
+CONFIG_USB_ROLES_INTEL_XHCI                     policy<{'amd64': '-'}>
+CONFIG_USB_ROLE_SWITCH                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_RTL8150                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_S2255                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_SERIAL_AIRCABLE                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_ARK3116                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_BELKIN                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_CH341                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_CYBERJACK                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_CYPRESS_M8                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_DIGI_ACCELEPORT               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_EDGEPORT                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_EDGEPORT_TI                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_EMPEG                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_F81232                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_F8153X                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_GARMIN                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_IPAQ                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_IPW                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_IR                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_IUU                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_KEYSPAN                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_KEYSPAN_PDA                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_KLSI                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_KOBIL_SCT                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_MCT_U232                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_METRO                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_MOS7715_PARPORT               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_SERIAL_MOS7720                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_MOS7840                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_MXUPORT                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_NAVMAN                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_OMNINET                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_OPTICON                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_OPTION                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_OTI6858                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_QCAUX                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_QT2                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_QUALCOMM                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_SAFE                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_SAFE_PADDED                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_SERIAL_SIERRAWIRELESS                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_SIMPLE                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_SPCP8X5                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_SSU100                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_SYMBOL                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_TI                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_UPD78F0730                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_VISOR                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_WHITEHEAT                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_WISHBONE                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_WWAN                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_SERIAL_XR                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SERIAL_XSENS_MT                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SEVSEG                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SI470X                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_SI4713                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_SIERRA_NET                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SISUSBVGA                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SL811_CS                             policy<{'amd64': '-'}>
+CONFIG_USB_SL811_HCD                            policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_SL811_HCD_ISO                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_SNP_CORE                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_SNP_UDC_PLAT                         policy<{'arm64': '-'}>
+CONFIG_USB_SPEEDTOUCH                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_STKWEBCAM                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_STORAGE_ALAUDA                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_CYPRESS_ATACB                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_DATAFAB                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_ENE_UB6250                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_FREECOM                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_ISD200                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_JUMPSHOT                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_KARMA                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_ONETOUCH                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_REALTEK                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_SDDR09                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_SDDR55                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STORAGE_USBAT                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_STV06XX                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_TEGRA_PHY                            policy<{'arm64': 'n'}>
+CONFIG_USB_TEGRA_XUDC                           policy<{'arm64': '-'}>
+CONFIG_USB_TEST                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_TMC                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_TRANCEVIBRATOR                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_U132_HCD                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_UEAGLEATM                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_ULPI_BUS                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_USS720                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_U_AUDIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_U_ETHER                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_U_SERIAL                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_VIDEO_CLASS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_VIDEO_CLASS_INPUT_EVDEV              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_VL600                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_WDM                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_XHCI_HISTB                           policy<{'arm64': '-'}>
+CONFIG_USB_XHCI_MTK                             policy<{'arm64': '-'}>
+CONFIG_USB_XHCI_MVEBU                           policy<{'arm64': '-'}>
+CONFIG_USB_XHCI_PCI_RENESAS                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_XHCI_PLATFORM                        policy<{'amd64': 'n', 'arm64': 'm'}>
+CONFIG_USB_XHCI_RCAR                            policy<{'arm64': '-'}>
+CONFIG_USB_XHCI_TEGRA                           policy<{'arm64': '-'}>
+CONFIG_USB_XUSBATM                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_YUREX                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USB_ZD1201                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_ZERO                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USB_ZR364XX                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_USELIB                                   policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_USERFAULTFD                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USERIO                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_USERMODE_DRIVER                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_UV_MMTIMER                               policy<{'amd64': '-'}>
+CONFIG_UV_SYSFS                                 policy<{'amd64': '-'}>
+CONFIG_U_SERIAL_CONSOLE                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_V4L2_ASYNC                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_V4L2_FLASH_LED_CLASS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_V4L2_FWNODE                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_V4L2_H264                                policy<{'arm64': '-'}>
+CONFIG_V4L2_JPEG_HELPER                         policy<{'arm64': '-'}>
+CONFIG_V4L2_MEM2MEM_DEV                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_V4L_MEM2MEM_DRIVERS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_V4L_PLATFORM_DRIVERS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_V4L_TEST_DRIVERS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VALIDATE_FS_PARSER                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VBOXGUEST                                policy<{'amd64': 'n'}>
+CONFIG_VBOXSF_FS                                policy<{'amd64': '-'}>
+CONFIG_VCHIQ_CDEV                               policy<{'arm64': '-'}>
+CONFIG_VCNL3020                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VCNL4000                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VCNL4035                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VDPA                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VDPA_SIM                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VDPA_SIM_BLOCK                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VDPA_SIM_NET                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VDPA_USER                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VEML6030                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VEML6070                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VF610_ADC                                policy<{'arm64': '-'}>
+CONFIG_VF610_DAC                                policy<{'arm64': '-'}>
+CONFIG_VFIO_AMBA                                policy<{'arm64': '-'}>
+CONFIG_VFIO_FSL_MC                              policy<{'arm64': '-'}>
+CONFIG_VFIO_MDEV                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VFIO_NOIOMMU                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VFIO_PLATFORM                            policy<{'arm64': 'n'}>
+CONFIG_VFIO_PLATFORM_AMDXGBE_RESET              policy<{'arm64': '-'}>
+CONFIG_VFIO_PLATFORM_BCMFLEXRM_RESET            policy<{'arm64': '-'}>
+CONFIG_VFIO_PLATFORM_CALXEDAXGMAC_RESET         policy<{'arm64': '-'}>
+CONFIG_VGASTATE                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VGA_SWITCHEROO                           policy<{'amd64': 'n'}>
+CONFIG_VHOST_RING                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VHOST_SCSI                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VHOST_VDPA                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VHOST_VSOCK                              policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_VIA_VELOCITY                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VIA_WDT                                  policy<{'amd64': 'n'}>
+CONFIG_VIDEOBUF2_CORE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF2_DMA_CONTIG                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF2_DMA_SG                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF2_DVB                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF2_MEMOPS                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF2_V4L2                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF2_VMALLOC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF_DMA_SG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF_GEN                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOBUF_VMALLOC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEOMODE_HELPERS                        policy<{'amd64': '-', 'arm64': 'y'}>
+CONFIG_VIDEO_AD5820                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_AD9389B                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADP1653                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7170                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7175                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7180                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7183                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7343                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7393                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV748X                            policy<{'arm64': '-'}>
+CONFIG_VIDEO_ADV7511                            policy<{'amd64': '-'}>
+CONFIG_VIDEO_ADV7511_CEC                        policy<{'amd64': '-'}>
+CONFIG_VIDEO_ADV7604                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7604_CEC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7842                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV7842_CEC                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ADV_DEBUG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_AK7375                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_AK881X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ALLEGRO_DVT                        policy<{'arm64': '-'}>
+CONFIG_VIDEO_APTINA_PLL                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ASPEED                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ATOMISP                            policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_GC0310                     policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_GC2235                     policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_ISP2401                    policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_LM3554                     policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_MSRLIST_HELPER             policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_MT9M114                    policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_OV2680                     policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_OV2722                     policy<{'amd64': '-'}>
+CONFIG_VIDEO_ATOMISP_OV5693                     policy<{'amd64': '-'}>
+CONFIG_VIDEO_AU0828                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_AU0828_RC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_AU0828_V4L2                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_BCM2835                            policy<{'arm64': '-'}>
+CONFIG_VIDEO_BT819                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_BT848                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_BT856                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_BT866                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CADENCE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CADENCE_CSI2RX                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CADENCE_CSI2TX                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CAFE_CCIC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CCS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CCS_PLL                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_COBALT                             policy<{'amd64': '-'}>
+CONFIG_VIDEO_CODA                               policy<{'arm64': '-'}>
+CONFIG_VIDEO_CPIA2                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CS3308                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CS5345                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CS53L32A                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX18                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX18_ALSA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX231XX                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX231XX_ALSA                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX231XX_DVB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX231XX_RC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX2341X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX23885                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX25821                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX25821_ALSA                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX25840                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX88                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX88_ALSA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX88_BLACKBIRD                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX88_DVB                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX88_ENABLE_VP3054                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX88_MPEG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_CX88_VP3054                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_DEV                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_DT3155                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_DW9714                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_DW9768                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_DW9807_VCM                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_EM28XX                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_EM28XX_ALSA                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_EM28XX_DVB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_EM28XX_RC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_EM28XX_V4L2                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ET8EK8                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_FB_IVTV                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_FB_IVTV_FORCE_PAT                  policy<{'amd64': '-'}>
+CONFIG_VIDEO_FIXED_MINOR_RANGES                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_GO7007                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_GO7007_LOADER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_GO7007_USB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_GO7007_USB_S2250_BOARD             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_GS1662                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_HANTRO                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_HANTRO_IMX8M                       policy<{'arm64': '-'}>
+CONFIG_VIDEO_HANTRO_ROCKCHIP                    policy<{'arm64': '-'}>
+CONFIG_VIDEO_HDPVR                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_HEXIUM_GEMINI                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_HEXIUM_ORION                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_HI556                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_HM11B1                             policy<{'amd64': '-'}>
+CONFIG_VIDEO_I2C                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX208                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX214                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX219                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX258                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX274                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX290                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX319                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX334                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_IMX335                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_IMX355                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IMX412                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_IMX7_CSI                           policy<{'arm64': '-'}>
+CONFIG_VIDEO_IMX8_JPEG                          policy<{'arm64': '-'}>
+CONFIG_VIDEO_IMX_MEDIA                          policy<{'arm64': '-'}>
+CONFIG_VIDEO_IMX_PXP                            policy<{'arm64': '-'}>
+CONFIG_VIDEO_INTEL_IPU6                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IPU3_CIO2                          policy<{'amd64': '-'}>
+CONFIG_VIDEO_IPU3_IMGU                          policy<{'amd64': '-'}>
+CONFIG_VIDEO_IR_I2C                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IVTV                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_IVTV_ALSA                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_KS0127                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_LM3560                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_LM3646                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_M52790                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_M5MOLS                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MAX9271_LIB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MAX9286                            policy<{'arm64': '-'}>
+CONFIG_VIDEO_MEDIATEK_VPU                       policy<{'arm64': '-'}>
+CONFIG_VIDEO_MEM2MEM_DEINTERLACE                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MESON_GE2D                         policy<{'arm64': '-'}>
+CONFIG_VIDEO_MESON_VDEC                         policy<{'arm64': '-'}>
+CONFIG_VIDEO_MEYE                               policy<{'amd64': '-'}>
+CONFIG_VIDEO_ML86V7667                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MSP3400                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9M001                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9M032                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9M111                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9P031                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9T001                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9T112                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9V011                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9V032                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MT9V111                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_MUX                                policy<{'arm64': '-'}>
+CONFIG_VIDEO_MXB                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_NOON010PC30                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV01A10                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV01A1S                            policy<{'amd64': '-'}>
+CONFIG_VIDEO_OV02A10                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV02C10                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV13858                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV2640                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV2659                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV2680                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV2685                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV2740                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV5640                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_OV5645                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_OV5647                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV5648                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV5670                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV5675                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV5695                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV6650                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV7251                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV7640                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV7670                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV772X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV7740                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV8856                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV8865                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV9282                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_OV9640                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV9650                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_OV9734                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_PCI_SKELETON                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_PVRUSB2                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_PVRUSB2_DEBUGIFC                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_PVRUSB2_DVB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_PVRUSB2_SYSFS                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_QCOM_CAMSS                         policy<{'arm64': '-'}>
+CONFIG_VIDEO_QCOM_VENUS                         policy<{'arm64': '-'}>
+CONFIG_VIDEO_RCAR_CSI2                          policy<{'arm64': '-'}>
+CONFIG_VIDEO_RCAR_DRIF                          policy<{'arm64': '-'}>
+CONFIG_VIDEO_RCAR_VIN                           policy<{'arm64': '-'}>
+CONFIG_VIDEO_RDACM20                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_RDACM21                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_RENESAS_FCP                        policy<{'arm64': '-'}>
+CONFIG_VIDEO_RENESAS_FDP1                       policy<{'arm64': '-'}>
+CONFIG_VIDEO_RENESAS_JPU                        policy<{'arm64': '-'}>
+CONFIG_VIDEO_RENESAS_VSP1                       policy<{'arm64': '-'}>
+CONFIG_VIDEO_RJ54N1                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ROCKCHIP_ISP1                      policy<{'arm64': '-'}>
+CONFIG_VIDEO_ROCKCHIP_RGA                       policy<{'arm64': '-'}>
+CONFIG_VIDEO_ROCKCHIP_VDEC                      policy<{'arm64': '-'}>
+CONFIG_VIDEO_S5C73M3                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_S5K4ECGX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_S5K5BAF                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_S5K6A3                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_S5K6AA                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA6588                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA6752HS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7110                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA711X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7127                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7134                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7134_ALSA                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7134_DVB                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7134_GO7007                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7134_RC                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7146                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7146_VV                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7164                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA717X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SAA7185                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SOLO6X10                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SONY_BTF_MPX                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SR030PC30                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_STK1160                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_STK1160_COMMON                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ST_MIPID02                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_SUN4I_CSI                          policy<{'arm64': '-'}>
+CONFIG_VIDEO_SUN6I_CSI                          policy<{'arm64': '-'}>
+CONFIG_VIDEO_SUN8I_DEINTERLACE                  policy<{'arm64': '-'}>
+CONFIG_VIDEO_SUN8I_ROTATE                       policy<{'arm64': '-'}>
+CONFIG_VIDEO_SUNXI                              policy<{'arm64': '-'}>
+CONFIG_VIDEO_SUNXI_CEDRUS                       policy<{'arm64': '-'}>
+CONFIG_VIDEO_TC358743                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TC358743_CEC                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TDA1997X                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TDA7432                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TDA9840                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TEA6415C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TEA6420                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TEGRA                              policy<{'arm64': '-'}>
+CONFIG_VIDEO_TEGRA_TPG                          policy<{'arm64': '-'}>
+CONFIG_VIDEO_THS7303                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_THS8200                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TI_CAL                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_TI_CAL_MC                          policy<{'arm64': '-'}>
+CONFIG_VIDEO_TLV320AIC23B                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TM6000                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TM6000_ALSA                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TM6000_DVB                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TUNER                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TVAUDIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TVEEPROM                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TVP514X                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TVP5150                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TVP7002                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TW2804                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TW5864                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TW68                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TW686X                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TW9903                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TW9906                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_TW9910                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_UDA1342                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_UPD64031A                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_UPD64083                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_USBTV                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_V4L2                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_V4L2_I2C                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_V4L2_SUBDEV_API                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_V4L2_TPG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VIA_CAMERA                         policy<{'amd64': '-'}>
+CONFIG_VIDEO_VICODEC                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VIM2M                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VIVID                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VIVID_CEC                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VIVID_MAX_DEVS                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VP27SMPX                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VPX3220                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_VS6624                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_WM8739                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_WM8775                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_XILINX                             policy<{'arm64': '-'}>
+CONFIG_VIDEO_XILINX_CSI2RXSS                    policy<{'arm64': '-'}>
+CONFIG_VIDEO_XILINX_TPG                         policy<{'arm64': '-'}>
+CONFIG_VIDEO_XILINX_VTC                         policy<{'arm64': '-'}>
+CONFIG_VIDEO_ZORAN                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ZORAN_AVS6EYES                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ZORAN_BUZ                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ZORAN_DC10                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ZORAN_DC30                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ZORAN_LML33                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ZORAN_LML33R10                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIDEO_ZORAN_ZR36060                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIPERBOARD_ADC                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIRTIO_BALLOON                           policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_VIRTIO_CONSOLE                           policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_VIRTIO_DMA_SHARED_BUFFER                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIRTIO_FS                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VIRTIO_IOMMU                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VIRTIO_PMEM                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIRTIO_VDPA                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VIRT_WIFI                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VISCONTI_WATCHDOG                        policy<{'arm64': '-'}>
+CONFIG_VITESSE_PHY                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VL53L0X_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VL6180                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VMAP_PFN                                 policy<{'amd64': '-'}>
+CONFIG_VMD                                      policy<{'amd64': 'n'}>
+CONFIG_VME_BUS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VME_CA91CX42                             policy<{'amd64': '-'}>
+CONFIG_VME_FAKE                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VME_TSI148                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VME_USER                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VMIVME_7805                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VMLINUX_MAP                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VMWARE_BALLOON                           policy<{'amd64': '-'}>
+CONFIG_VMXNET3                                  policy<{'amd64': 'm', 'arm64': 'n'}>
+CONFIG_VORTEX                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VP_VDPA                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VSOCKMON                                 policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_VT6655                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VT6656                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_VXFS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VZ89X                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1                                       policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_W1_CON                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_MASTER_DS1WM                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_MASTER_DS2482                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_MASTER_DS2490                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_MASTER_GPIO                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_MASTER_MATROX                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_MASTER_MXC                            policy<{'arm64': '-'}>
+CONFIG_W1_MASTER_SGI                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2405                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2406                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2408                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2408_READBACK                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2413                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2423                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2430                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2431                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2433                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2433_CRC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2438                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS250X                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2780                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2781                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS2805                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS28E04                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_DS28E17                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_SMEM                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W1_SLAVE_THERM                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_W83627HF_WDT                             policy<{'amd64': 'n'}>
+CONFIG_W83877F_WDT                              policy<{'amd64': 'n'}>
+CONFIG_W83977F_WDT                              policy<{'amd64': 'n'}>
+CONFIG_WAFER_WDT                                policy<{'amd64': 'n'}>
+CONFIG_WAN                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WANT_COMPAT_NETLINK_MESSAGES             policy<{'amd64': '-'}>
+CONFIG_WANT_DEV_COREDUMP                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WANXL                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WATCHDOG_CORE                            policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_WATCHDOG_PRETIMEOUT_DEFAULT_GOV_NOOP     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WATCHDOG_PRETIMEOUT_DEFAULT_GOV_PANIC    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WATCHDOG_PRETIMEOUT_GOV                  policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WATCHDOG_PRETIMEOUT_GOV_NOOP             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WATCHDOG_PRETIMEOUT_GOV_PANIC            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WATCHDOG_PRETIMEOUT_GOV_SEL              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WATCHDOG_SYSFS                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WATCH_QUEUE                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WCN36XX                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WCN36XX_DEBUGFS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WDAT_WDT                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WDTPCI                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WEXT_CORE                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WEXT_PRIV                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WEXT_PROC                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WEXT_SPY                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WFX                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIL6210                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIL6210_DEBUGFS                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIL6210_ISR_COR                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIL6210_TRACING                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WILC1000                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WILC1000_HW_OOB_INTR                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WILC1000_SDIO                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WILC1000_SPI                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WILCO_EC                                 policy<{'amd64': '-'}>
+CONFIG_WILCO_EC_DEBUGFS                         policy<{'amd64': '-'}>
+CONFIG_WILCO_EC_EVENTS                          policy<{'amd64': '-'}>
+CONFIG_WILCO_EC_TELEMETRY                       policy<{'amd64': '-'}>
+CONFIG_WILINK_PLATFORM_DATA                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WINBOND_840                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WIRELESS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WIRELESS_EXT                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIRELESS_HOTKEY                          policy<{'amd64': 'n'}>
+CONFIG_WIZNET_BUS_ANY                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIZNET_BUS_DIRECT                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIZNET_BUS_INDIRECT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIZNET_W5100                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIZNET_W5100_SPI                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WIZNET_W5300                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WL1251                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WL1251_SDIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WL1251_SPI                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WL12XX                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WL18XX                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN                                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WLAN_VENDOR_ADMTEK                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_ATH                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_ATMEL                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_BROADCOM                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_CISCO                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_INTEL                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_INTERSIL                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_MARVELL                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_MEDIATEK                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_MICROCHIP                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_QUANTENNA                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_RALINK                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_REALTEK                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_RSI                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_ST                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_TI                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLAN_VENDOR_ZYDAS                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLCORE                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLCORE_SDIO                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WLCORE_SPI                               policy<{'arm64': '-'}>
+CONFIG_WM831X_BACKUP                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WM831X_POWER                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WM831X_WATCHDOG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WM8350_POWER                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WM8350_WATCHDOG                          policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_WMI_BMOF                                 policy<{'amd64': '-'}>
+CONFIG_WQ_POWER_EFFICIENT_DEFAULT               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_WWAN_HWSIM                               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_X25                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_X86_16BIT                                policy<{'amd64': 'n'}>
+CONFIG_X86_ACPI_CPUFREQ_CPB                     policy<{'amd64': 'n'}>
+CONFIG_X86_AMD_PLATFORM_DEVICE                  policy<{'amd64': 'n'}>
+CONFIG_X86_AMD_PSTATE                           policy<{'amd64': 'n'}>
+CONFIG_X86_BOOTPARAM_MEMORY_CORRUPTION_CHECK    policy<{'amd64': 'n'}>
+CONFIG_X86_CPU_RESCTRL                          policy<{'amd64': 'n'}>
+CONFIG_X86_ESPFIX64                             policy<{'amd64': '-'}>
+CONFIG_X86_EXTENDED_PLATFORM                    policy<{'amd64': 'n'}>
+CONFIG_X86_GOLDFISH                             policy<{'amd64': '-'}>
+CONFIG_X86_INTEL_MID                            policy<{'amd64': '-'}>
+CONFIG_X86_INTEL_TSX_MODE_OFF                   policy<{'amd64': 'n'}>
+CONFIG_X86_INTEL_TSX_MODE_ON                    policy<{'amd64': 'y'}>
+CONFIG_X86_MCELOG_LEGACY                        policy<{'amd64': 'n'}>
+CONFIG_X86_MCE_INJECT                           policy<{'amd64': 'n'}>
+CONFIG_X86_MPPARSE                              policy<{'amd64': 'n'}>
+CONFIG_X86_NUMACHIP                             policy<{'amd64': '-'}>
+CONFIG_X86_P4_CLOCKMOD                          policy<{'amd64': 'n'}>
+CONFIG_X86_PLATFORM_DRIVERS_HP                  policy<{'amd64': 'n'}>
+CONFIG_X86_PMEM_LEGACY                          policy<{'amd64': 'n'}>
+CONFIG_X86_PMEM_LEGACY_DEVICE                   policy<{'amd64': '-'}>
+CONFIG_X86_SGX                                  policy<{'amd64': 'n'}>
+CONFIG_X86_SGX_KVM                              policy<{'amd64': '-'}>
+CONFIG_X86_SPEEDSTEP_LIB                        policy<{'amd64': '-'}>
+CONFIG_X86_VERBOSE_BOOTUP                       policy<{'amd64': 'y'}>
+CONFIG_X86_VSMP                                 policy<{'amd64': '-'}>
+CONFIG_X86_X32                                  policy<{'amd64': 'n'}>
+CONFIG_XDP_SOCKETS                              policy<{'amd64': 'y', 'arm64': 'n'}>
+CONFIG_XDP_SOCKETS_DIAG                         policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_XEN_BALLOON_MEMORY_HOTPLUG               policy<{'amd64': 'y', 'arm64': '-'}>
+CONFIG_XEN_DEBUG_FS                             policy<{'amd64': 'y'}>
+CONFIG_XEN_FRONT_PGDIR_SHBUF                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_XEN_GNTDEV_DMABUF                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_XEN_GRANT_DMA_ALLOC                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XEN_PVCALLS_FRONTEND                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XEN_SCSI_BACKEND                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XEN_UNPOPULATED_ALLOC                    policy<{'amd64': '-'}>
+CONFIG_XFRM_ESPINTCP                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_XFRM_INTERFACE                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XFRM_MIGRATE                             policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_XFRM_OFFLOAD                             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_XFRM_SUB_POLICY                          policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_XFRM_USER_COMPAT                         policy<{'amd64': 'n'}>
+CONFIG_XFS_RT                                   policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XGENE_DMA                                policy<{'arm64': 'y'}>
+CONFIG_XGENE_PMU                                policy<{'arm64': 'n'}>
+CONFIG_XGENE_SLIMPRO_MBOX                       policy<{'arm64': 'n'}>
+CONFIG_XIAOMI_WMI                               policy<{'amd64': '-'}>
+CONFIG_XILINX_AXI_EMAC                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XILINX_DMA                               policy<{'arm64': 'n'}>
+CONFIG_XILINX_EMACLITE                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XILINX_GMII2RGMII                        policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XILINX_INTC                              policy<{'arm64': '-'}>
+CONFIG_XILINX_LL_TEMAC                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XILINX_PR_DECOUPLER                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_XILINX_SDFEC                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XILINX_VCU                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XILINX_WATCHDOG                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XILINX_XADC                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_XILINX_ZYNQMP_DMA                        policy<{'arm64': 'n'}>
+CONFIG_XILINX_ZYNQMP_DPDMA                      policy<{'arm64': 'n'}>
+CONFIG_XILLYBUS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XILLYBUS_CLASS                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_XILLYBUS_OF                              policy<{'arm64': '-'}>
+CONFIG_XILLYBUS_PCIE                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_XILLYUSB                                 policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XIL_AXIS_FIFO                            policy<{'arm64': '-'}>
+CONFIG_XPOWER_PMIC_OPREGION                     policy<{'amd64': '-'}>
+CONFIG_XZ_DEC_ARM                               policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XZ_DEC_ARMTHUMB                          policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XZ_DEC_IA64                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XZ_DEC_POWERPC                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XZ_DEC_SPARC                             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_XZ_DEC_TEST                              policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_YAM                                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_YAMAHA_YAS530                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_YELLOWFIN                                policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_YENTA                                    policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_YENTA_ENE_TUNE                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_YENTA_O2                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_YENTA_RICOH                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_YENTA_TI                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_YENTA_TOSHIBA                            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_Z3FOLD                                   policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZBUD                                     policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZD1211RW                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZD1211RW_DEBUG                           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZEROPLUS_FF                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZIIRAVE_WATCHDOG                         policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ZONEFS_FS                                policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZONE_DEVICE                              policy<{'amd64': 'n', 'arm64': '-'}>
+CONFIG_ZOPT2201                                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZPA2326                                  policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZPA2326_I2C                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZPA2326_SPI                              policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZPOOL                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ZRAM_DEF_COMP_842                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZRAM_DEF_COMP_LZ4                        policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZRAM_DEF_COMP_LZ4HC                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZRAM_DEF_COMP_ZSTD                       policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZRAM_MEMORY_TRACKING                     policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ZRAM_WRITEBACK                           policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ZSMALLOC                                 policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_ZSWAP                                    policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT_842             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT_DEFLATE         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT_LZ4             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT_LZ4HC           policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT_LZO             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT_ZSTD            policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_DEFAULT_ON                         policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_ZPOOL_DEFAULT                      policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_ZPOOL_DEFAULT_Z3FOLD               policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_ZPOOL_DEFAULT_ZBUD                 policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZSWAP_ZPOOL_DEFAULT_ZSMALLOC             policy<{'amd64': '-', 'arm64': '-'}>
+CONFIG_ZYNQMP_FIRMWARE                          policy<{'arm64': '-'}>
+CONFIG_ZYNQMP_FIRMWARE_DEBUG                    policy<{'arm64': '-'}>
+CONFIG_ZYNQMP_IPI_MBOX                          policy<{'arm64': '-'}>
+CONFIG_ZYNQMP_PM_DOMAINS                        policy<{'arm64': '-'}>
+CONFIG_ZYNQMP_POWER                             policy<{'arm64': '-'}>

--- a/overlay/debian.k3os/rules.d/amd64.mk
+++ b/overlay/debian.k3os/rules.d/amd64.mk
@@ -22,5 +22,7 @@ do_tools_common = true
 do_tools_acpidbg = true
 do_odm_drivers  = false
 do_zfs      = false
+do_v4l2loopback = false
+do_iwlwifi = false
 do_dkms_nvidia = false
 do_dkms_nvidia_server = false

--- a/overlay/debian.k3os/rules.d/arm64.mk
+++ b/overlay/debian.k3os/rules.d/arm64.mk
@@ -20,5 +20,7 @@ do_tools_bpftool = true
 
 do_dtbs		= true
 do_zfs      = false
+do_v4l2loopback = false
+do_iwlwifi = false
 do_dkms_nvidia = false
 do_dkms_nvidia_server = false


### PR DESCRIPTION
Major pruning
    
Disabled a lot of kernel options following closely to Flatcar Linux's kernel configuration

Disabled all the dynamic kernel modules